### PR TITLE
Use $fetch instead of axios

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -11,4 +11,7 @@ import '@gouvfr/dsfr/dist/utility/utility.css'
 import '~/assets/css/overrides.css'
 
 provideHeadlessUseId(() => useId())
+
+const me = useMaybeMe();
+await callOnce(async () => await refreshMe(me))
 </script>

--- a/components/SiteHeader/SiteHeader.vue
+++ b/components/SiteHeader/SiteHeader.vue
@@ -184,7 +184,10 @@
                 class="fr-nav__link"
                 href="#"
                 target="_self"
-              >accès direct</a>
+              >
+              {{ counter }}
+
+            </a>
             </li>
             <li class="fr-nav__item">
               <a
@@ -232,7 +235,9 @@
                 class="fr-nav__link"
                 href="#"
                 target="_self"
-              >accès direct</a>
+              >
+                {{ counter }}
+            </a>
             </li>
             <li class="fr-nav__item">
               <a
@@ -263,7 +268,9 @@
 </template>
 
 <script setup lang="ts">
-import { useMe } from '~/utils/auth';
+import { useMaybeMe } from '~/utils/auth';
+
+const counter = useState('counter', () => Math.round(Math.random() * 1000))
 
 const menuModalId = useId()
 const menuButtonId = useId()
@@ -290,5 +297,5 @@ function closeMenuModal() {
   menuOpened.value = false
 }
 
-const me = useMe();
+const me = useMaybeMe();
 </script>

--- a/components/SiteHeader/SiteHeader.vue
+++ b/components/SiteHeader/SiteHeader.vue
@@ -76,10 +76,9 @@
                     </a>
                 </li>
                 <li>
-                  <!-- TODO do not use `GET` request for logout -->
-                  <a href="/en/logout" class="fr-btn fr-icon-logout-box-r-line">
+                  <button @click="logout" class="fr-btn fr-icon-logout-box-r-line">
                     Logout
-                  </a>
+                  </button>
                 </li>
               </ul>
               <ul class="fr-btns-group" v-else>
@@ -185,8 +184,7 @@
                 href="#"
                 target="_self"
               >
-              {{ counter }}
-
+              accès direct
             </a>
             </li>
             <li class="fr-nav__item">
@@ -236,7 +234,7 @@
                 href="#"
                 target="_self"
               >
-                {{ counter }}
+                accès direct
             </a>
             </li>
             <li class="fr-nav__item">
@@ -270,8 +268,6 @@
 <script setup lang="ts">
 import { useMaybeMe } from '~/utils/auth';
 
-const counter = useState('counter', () => Math.round(Math.random() * 1000))
-
 const menuModalId = useId()
 const menuButtonId = useId()
 const searchModalId = useId()
@@ -298,4 +294,15 @@ function closeMenuModal() {
 }
 
 const me = useMaybeMe();
+
+const token = useToken();
+const session = useCookie('session')
+const logout = async () => {
+  token.value = null;
+  session.value = null;
+
+  await refreshMe(me);
+  await navigateTo('/en/login');
+}
+
 </script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,12 @@ export default defineNuxtConfig({
   compatibilityDate: '2024-04-03',
   devtools: { enabled: true },
 
+  runtimeConfig: {
+    public: {
+      apiBase: 'http://dev.local:7000'
+    },
+  },
+
   typescript: {
     typeCheck: true,
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,7 +10,7 @@ export default defineNuxtConfig({
   },
 
   typescript: {
-    typeCheck: true,
+    typeCheck: false,
   },
   // required for nuxt/content
   ssr: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.7.7",
         "nuxt": "^3.13.0",
         "nuxt-headlessui": "^1.2.0",
+        "ofetch": "^1.4.1",
         "vue": "latest",
         "vue-router": "latest"
       },
@@ -11489,13 +11490,14 @@
       }
     },
     "node_modules/ofetch": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.3.4.tgz",
-      "integrity": "sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
+      "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+      "license": "MIT",
       "dependencies": {
         "destr": "^2.0.3",
-        "node-fetch-native": "^1.6.3",
-        "ufo": "^1.5.3"
+        "node-fetch-native": "^1.6.4",
+        "ufo": "^1.5.4"
       }
     },
     "node_modules/ohash": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.7.7",
     "nuxt": "^3.13.0",
     "nuxt-headlessui": "^1.2.0",
+    "ofetch": "^1.4.1",
     "vue": "latest",
     "vue-router": "latest"
   },

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -46,8 +46,9 @@ async function send() {
     headers: { 'X-CSRF-Token': csrfToken },
     credentials: 'include',
   })
-  token.value = response.response.user.authentication_token
+  // token.value = response.response.user.authentication_token
 
   await refreshMe(me)
+  await navigateTo('/en/newadmin')
 }
 </script>

--- a/pages/newadmin/index.vue
+++ b/pages/newadmin/index.vue
@@ -2,15 +2,14 @@
     <h1>Hello World!</h1>
 
     <ul>
-        <li v-for="dataset in datasets">{{ dataset.title }}</li>
+        <li v-for="dataset in datasets.data">{{ dataset.title }}</li>
     </ul>
 
     <NuxtLink href="/fr/newadmin/test">Go to test</NuxtLink>
 </template>
 <script setup lang="ts">
-const runtimeConfig = useRuntimeConfig()
+import type { Dataset } from '@datagouv/components/ts';
+import { type PaginatedArray } from '~/utils/api';
 
-const { data } = await useFetch(`${runtimeConfig.public.apiBase}/api/1/datasets`)
-
-const datasets = computed(() => (data.value as any).data)
+const { data: datasets } = await useAPI<PaginatedArray<Dataset>>('/api/1/datasets')
 </script>

--- a/pages/newadmin/index.vue
+++ b/pages/newadmin/index.vue
@@ -1,5 +1,16 @@
 <template>
     <h1>Hello World!</h1>
 
+    <ul>
+        <li v-for="dataset in datasets">{{ dataset.title }}</li>
+    </ul>
+
     <NuxtLink href="/fr/newadmin/test">Go to test</NuxtLink>
 </template>
+<script setup lang="ts">
+const runtimeConfig = useRuntimeConfig()
+
+const { data } = await useFetch(`${runtimeConfig.public.apiBase}/api/1/datasets`)
+
+const datasets = computed(() => (data.value as any).data)
+</script>

--- a/plugins/api.ts
+++ b/plugins/api.ts
@@ -1,0 +1,24 @@
+export default defineNuxtPlugin((nuxtApp) => {
+    const config = useRuntimeConfig()
+
+    const api = $fetch.create({
+      baseURL: config.public.apiBase,
+      onRequest({ options }) {
+        options.headers.set('Content-Type', 'application/json')
+        options.headers.set('Accept', 'application/json')
+        options.credentials = 'include'
+      },
+      async onResponseError({ response }) {
+        if (response.status === 401) {
+            await nuxtApp.runWithContext(() => navigateTo('/login'))
+        }
+      }
+    })
+  
+    // Expose to useNuxtApp().$api
+    return {
+      provide: {
+        api
+      }
+    }
+  })

--- a/plugins/api.ts
+++ b/plugins/api.ts
@@ -1,5 +1,7 @@
 export default defineNuxtPlugin((nuxtApp) => {
     const config = useRuntimeConfig()
+    const token = useToken();
+    const cookie = useRequestHeader('cookie');
 
     const api = $fetch.create({
       baseURL: config.public.apiBase,
@@ -7,6 +9,12 @@ export default defineNuxtPlugin((nuxtApp) => {
         options.headers.set('Content-Type', 'application/json')
         options.headers.set('Accept', 'application/json')
         options.credentials = 'include'
+        if (token.value) {
+          options.headers.set('Authentication-Token', token.value)
+        }
+        if (cookie) {
+          options.headers.set('Cookie', cookie)
+        }
       },
       async onResponseError({ response }) {
         if (response.status === 401) {

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,7 +1,29 @@
-import axios from "axios";
+import type { UseFetchOptions } from 'nuxt/app'
 
-axios.defaults.withCredentials = true
+export type PaginatedArray<T> = {
+    data: Array<T>;
+    next_page: string | null;
+    page: number;
+    page_size: number;
+    previous_page: string | null;
+    total: number;
+};
 
-export function get(url: string) {
-    return axios.get(url)
+export function useAPI<T>(
+  url: string | (() => string),
+  options?: UseFetchOptions<T>,
+) {
+    return useFetch(url, {
+        ...options,
+        $fetch: useNuxtApp().$api
+    }).then((response) => {
+        // This allow to remove the `null` variant from `useFetch`
+        // response. I think the `null` variant is here for `DELETE`
+        // responses (without body) but in our case this helper is intended 
+        // to be used only for `GET` requests. We need to use $fetch for 
+        // the others HTTP methods.
+        // TODO: add a check at the beginning of this function to prevent 
+        // miss-use of this function (calling it with other methods)
+        return { ...response, data: response.data as T }
+    })
 }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,18 +1,30 @@
 import type { User } from "@datagouv/components";
-import { get } from "./api"
-import { onMounted } from "vue";
 
-const me = ref<User | null>(null);
-
-export const reloadAuth = async () => {
-    const response = await get('http://dev.local:7000/api/1/me')
-    me.value = response.data
+export const useMe = () => {
+    return useAPI<User>('/api/1/me')
+        .then((response) => ({ ...response, me: response.data as any as User}))
 }
 
-export const useMe = (): Ref<User | null> => {
-    onMounted(async () => {
-        reloadAuth()
-    })
+export const useMaybeMe = () => {
+    return useState<User | null>('me')
+}
 
-    return me
+export const refreshMe = async (meState: Ref<User | null>) => {
+    // Here we cannot use the `useAPI` composable because
+    // we don't want the classic error management that redirect
+    // to the login page when a 401 is raised. So we must manually
+    // re-configured the baseURL.
+
+    const config = useRuntimeConfig()
+    const headers = useRequestHeaders(['cookie'])
+
+    try {
+        meState.value = await $fetch<User | null>('/api/1/me', {
+            baseURL: config.public.apiBase,
+            // headers,
+        })
+    } catch (e) {
+        console.error(e)
+        meState.value = null
+    }
 }


### PR DESCRIPTION
If you run the app with Docker this page http://localhost:3000/fr/newadmin should work without JS and print the list of datasets (fetched from the server)

Need to run with `--network=host`

```
docker run --rm -it --network="host" -p 3000:3000 --name front-end front-end
```

Some token stuff is still present because I don't know which one will be using in the future… But the auth is using session (so we must be on the same domain, use dev.local:3000 for example)