### PR TITLE
Add business documentation url property on dataservice

### DIFF
--- a/components/Dataservices/DescribeDataservice.vue
+++ b/components/Dataservices/DescribeDataservice.vue
@@ -118,6 +118,15 @@
           </p>
         </Accordion>
         <Accordion
+          :id="addBusinessUrlAccordionId"
+          :title="t('Add a link to the business documentation')"
+          :state="accordionState('business_documentation_url')"
+        >
+          <p class="fr-m-0">
+            {{ t("The business documentation of your API that explains its capabilities and use cases, in addition to the technical documentation.") }}
+          </p>
+        </Accordion>
+        <Accordion
           :id="rateLimitingDataserviceAccordionId"
           :title="t('Set the rate limiting')"
           :state="accordionState('rate_limiting')"
@@ -353,13 +362,30 @@
             <InputGroup
               v-model="form.endpoint_description_url"
               :aria-describedby="addEndpointUrlAccordionId"
-              :label="t('Dataservice endpoint URL')"
+              :label="t('Dataservice endpoint description URL')"
               type="url"
               :placeholder="t('https://...')"
               :required="false"
               :has-error="!!getFirstError('endpoint_description_url')"
               :has-warning="!!getFirstWarning('endpoint_description_url')"
               :error-text="getFirstError('endpoint_description_url')"
+            />
+          </LinkedToAccordion>
+          <LinkedToAccordion
+            class="fr-fieldset__element"
+            :accordion="addBusinessUrlAccordionId"
+            @blur="touch('business_documentation_url')"
+          >
+            <InputGroup
+              v-model="form.business_documentation_url"
+              :aria-describedby="addBusinessUrlAccordionId"
+              :label="t('Dataservice business documentation URL')"
+              type="url"
+              :placeholder="t('https://...')"
+              :required="false"
+              :has-error="!!getFirstError('business_documentation_url')"
+              :has-warning="!!getFirstWarning('business_documentation_url')"
+              :error-text="getFirstError('business_documentation_url')"
             />
           </LinkedToAccordion>
           <LinkedToAccordion
@@ -433,6 +459,7 @@ const selectHasTokenAccordionId = useId()
 const addBaseUrlAccordionId = useId()
 const addAuthorizationUrlAccordionId = useId()
 const addEndpointUrlAccordionId = useId()
+const addBusinessUrlAccordionId = useId()
 const rateLimitingDataserviceAccordionId = useId()
 const availabilityDataserviceAccordionId = useId()
 const contactPointAccordionId = useId()
@@ -448,6 +475,7 @@ const { form, touch, getFirstError, getFirstWarning, validate } = useForm(datase
   base_api_url: [url()],
   authorization_request_url: [url()],
   endpoint_description_url: [url()],
+  business_documentation_url: [url()],
 }, {
   description: [minLength(200, t('It\'s advised to have a {property} of at least {min} characters.', { property: t('description'), min: 200 }))],
 })

--- a/pages/beta/admin/dataservices/new.vue
+++ b/pages/beta/admin/dataservices/new.vue
@@ -94,6 +94,7 @@ const dataserviceForm = useState(
       base_api_url: '',
       datasets: [],
       endpoint_description_url: '',
+      business_documentation_url: '',
       has_token: false,
       is_restricted: false,
       license: null,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -209,6 +209,7 @@ export type DataserviceForm = {
   base_api_url: string
   authorization_request_url: string
   endpoint_description_url: string
+  business_documentation_url: string
   rate_limiting: string
   availability: string
 }
@@ -227,6 +228,7 @@ export type NewDataserviceForApi = {
   base_api_url: string | null
   authorization_request_url: string | null
   endpoint_description_url: string | null
+  business_documentation_url: string | null
   rate_limiting: string
   availability: number | null
 }

--- a/utils/dataservices.ts
+++ b/utils/dataservices.ts
@@ -22,6 +22,7 @@ export function toForm(dataservice: Dataservice): DataserviceForm {
     base_api_url: dataservice.base_api_url || '',
     authorization_request_url: dataservice.authorization_request_url || '',
     endpoint_description_url: dataservice.endpoint_description_url || '',
+    business_documentation_url: dataservice.business_documentation_url || '',
     rate_limiting: dataservice.rate_limiting,
     availability: dataservice.availability?.toString() || '',
   }
@@ -42,6 +43,7 @@ export function toApi(form: DataserviceForm, overrides: { datasets?: Array<Datas
     base_api_url: form.base_api_url || null,
     authorization_request_url: form.authorization_request_url || null,
     endpoint_description_url: form.endpoint_description_url || null,
+    business_documentation_url: form.business_documentation_url || null,
     rate_limiting: form.rate_limiting,
     availability: form.availability ? parseFloat(form.availability) : null,
   }


### PR DESCRIPTION
Related to https://github.com/datagouv/data.gouv.fr/issues/1561.

`business_documentation_url` is being added in https://github.com/opendatateam/udata/pull/3193.

Copy/pasted the logic from `endpoint_description_url`.
Validation does not seem to work properly on dataservice form but it doesn't seem specific to this metadata.