### PR TITLE
Add minimal error page

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,33 @@
+<template>
+  <NuxtLayout>
+    <div class="fr-container fr-py-9v">
+      <div class="prose">
+        <template v-if="error.statusCode === 404">
+          <h1>{{ $t('Error 404') }}</h1>
+          <p>{{ $t("The page you're looking for cannot be found.") }}</p>
+        </template>
+        <template v-else>
+          <h1>{{ $t('Error') }}</h1>
+          <p>{{ $t('Something did not work as expected.') }}</p>
+
+          <p>
+            <strong>{{ error.message }}</strong>
+          </p>
+        </template>
+        <p>
+          <a
+            class="fr-link fr-reset-link"
+            href="/"
+          >
+            {{ $t('Home') }}
+          </a>
+        </p>
+      </div>
+    </div>
+  </NuxtLayout>
+</template>
+
+<script setup>
+const { t } = useI18n()
+const error = useError()
+</script>

--- a/lang/fr-FR.json
+++ b/lang/fr-FR.json
@@ -708,5 +708,9 @@
   "format": "format",
   "on {date}": "le {date}",
   "today": "aujourd'hui",
+  "Error 404": "Erreur 404",
+  "The page you're looking for cannot be found.": "La page que vous cherchez ne peut être trouvée.",
+  "Error": "Erreur",
+  "Something did not work as expected.": "Quelque chose ne s'est pas passé comme prévu",
   "": ""
 }


### PR DESCRIPTION
Deal with 404 and display generic message for other errors.

Inspired by minimal example in https://nuxt.com/docs/examples/advanced/error-handling and https://masteringnuxt.com/blog/custom-error-pages-in-nuxt3.
Did not deal with a `clearError` button yet.