### PR TITLE
Fix logout is not routed by Nuxt

### DIFF
--- a/components/SiteHeader/SiteHeader.vue
+++ b/components/SiteHeader/SiteHeader.vue
@@ -98,12 +98,12 @@
                   </NuxtLinkLocale>
                 </li>
                 <li>
-                  <NuxtLinkLocale
-                    to="/logout"
+                  <a
+                    :href="`${config.public.apiBase}/logout`"
                     class="fr-btn fr-icon-logout-box-r-line"
                   >
                     {{ $t('Logout') }}
-                  </NuxtLinkLocale>
+                </a>
                 </li>
               </ul>
               <ul

--- a/components/SiteHeader/SiteHeader.vue
+++ b/components/SiteHeader/SiteHeader.vue
@@ -103,7 +103,7 @@
                     class="fr-btn fr-icon-logout-box-r-line"
                   >
                     {{ $t('Logout') }}
-                </a>
+                  </a>
                 </li>
               </ul>
               <ul


### PR DESCRIPTION
Use `<a>` instead of `<NuxtLinkLocale>` wrongly introduced in https://github.com/datagouv/front-end/pull/144/