### PR TITLE
Trim scheme from environment in sentry config

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/nuxt";
 
 Sentry.init({
   dsn: useRuntimeConfig().public.sentry.dsn,
-  environment: useRuntimeConfig().public.apiBase,
+  environment: useRuntimeConfig().public.apiBase.replace(/https?:\/\//, ''),
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,7 +6,7 @@ dotenv.config()
 Sentry.init({
   // We can't read useRuntimeConfig here, reading configs from .env
   dsn: process.env.NUXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NUXT_PUBLIC_API_BASE,
+  environment: process.env.NUXT_PUBLIC_API_BASE?.replace(/https?:\/\//, ''),
 
   // We recommend adjusting this value in production, or using tracesSampler
   // for finer control


### PR DESCRIPTION
Following https://github.com/datagouv/front-end/pull/146.

Sentry complains with `environment: Discarded invalid value`, probably due to it being a URL