### PR TITLE
Fix favicon

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -79,7 +79,10 @@ export default defineNuxtConfig({
         class: 'datagouv-components',
       },
       link: [
-        { rel: 'shortcut icon', href: '/favicon.png' },
+        // Cannot use `/public/favicon.png` because the reverse proxy is calling udata-front for `/`
+        // When the migration is over we can remove this static path.
+        // :AfterMigration
+        { rel: 'shortcut icon', href: 'https://static.data.gouv.fr/_themes/gouvfr/img/favicon.png' },
       ],
     },
   },


### PR DESCRIPTION
Cannot use `/public/favicon.png` because the reverse proxy is calling udata-front for `/`
When the migration is over we can remove this static path.