### PR TITLE
Add job page with items list

### DIFF
--- a/components/Harvesters/AdminHarvestersPage.vue
+++ b/components/Harvesters/AdminHarvestersPage.vue
@@ -89,7 +89,14 @@
               </td>
               <td>
                 <AdminBadge
-                  v-if="harvester.validation.state === 'refused'"
+                  v-if="!harvester.active"
+                  size="xs"
+                  type="danger"
+                >
+                  {{ $t('Inactive') }}
+                </AdminBadge>
+                <AdminBadge
+                  v-else-if="harvester.validation.state === 'refused'"
                   size="xs"
                   type="danger"
                 >

--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -790,5 +790,6 @@
   "An archived dataset is no longer indexed but still accessible for users with the direct link.": "An archived dataset is no longer indexed but still accessible for users with the direct link.",
   "Dataset unarchived!": "Dataset unarchived!",
   "Dataset archived!": "Dataset archived!",
+  "{n} items": "{n} items | {n} item | {n} items",
   "": ""
 }

--- a/lang/es-ES.json
+++ b/lang/es-ES.json
@@ -783,5 +783,6 @@
   "An archived dataset is no longer indexed but still accessible for users with the direct link.": "An archived dataset is no longer indexed but still accessible for users with the direct link.",
   "Dataset unarchived!": "Dataset unarchived!",
   "Dataset archived!": "Dataset archived!",
+  "{n} items": "{n} items | {n} item | {n} items",
   "": ""
 }

--- a/lang/fr-FR.json
+++ b/lang/fr-FR.json
@@ -811,5 +811,6 @@
   "An archived dataset is no longer indexed but still accessible for users with the direct link.": "Un jeu de données archivé n'est plus indexé mais reste accessible aux utilisateurs avec un lien direct.",
   "Dataset unarchived!": "Jeu de données désarchivé!",
   "Dataset archived!": "Jeu de données archivé!",
+  "{n} items": "{n} éléments | {n} élément | {n} éléments",
   "": ""
 }

--- a/pages/beta/admin/harvesters/[id].vue
+++ b/pages/beta/admin/harvesters/[id].vue
@@ -26,7 +26,25 @@
             {{ t('Harvesters') }}
           </NuxtLinkLocale>
         </li>
-        <li>
+        <template v-if="job">
+          <li>
+            <NuxtLinkLocale
+              class="fr-breadcrumb__link"
+              :to="getHarvesterAdminUrl(harvester)"
+            >
+              {{ harvester.name }}
+            </NuxtLinkLocale>
+          </li>
+          <li>
+            <a
+              class="fr-breadcrumb__link"
+              aria-current="page"
+            >
+              {{ job.id }}
+            </a>
+          </li>
+        </template>
+        <li v-else>
           <a
             class="fr-breadcrumb__link"
             aria-current="page"
@@ -37,7 +55,7 @@
       </template>
     </Breadcrumb>
 
-    <div v-if="harvester">
+    <div v-if="harvester && !job">
       <div class="mb-5">
         <div class="flex items-center justify-between mb-3">
           <h1 class="fr-h3 !mb-0">
@@ -58,17 +76,17 @@
           <div class="space-x-1">
             <RiToolsLine class="inline size-3" />
             <span>{{ $t('Implementation:') }}</span>
-            <span class="text-mono">{{ harvester.backend }}</span>
+            <span class="font-mono">{{ harvester.backend }}</span>
           </div>
           <div class="space-x-1">
             <RiLink class="inline size-3" />
             <span>{{ $t('URL:') }}</span>
-            <span class="text-mono">{{ harvester.url }}</span>
+            <span class="font-mono">{{ harvester.url }}</span>
           </div>
           <div class="space-x-1">
             <RiCalendarEventLine class="inline size-3" />
             <span>{{ $t('Schedule:') }}</span>
-            <span class="text-mono">{{ harvester.schedule || 'N/A' }}</span>
+            <span class="font-mono">{{ harvester.schedule || 'N/A' }}</span>
           </div>
           <div
             v-if="harvester.validation.state !== 'accepted'"
@@ -101,16 +119,16 @@
           // { href: `${getharvesterAdminUrl(harvester)}/files`, label: t('Files') },
         ]"
       />
-
-      <NuxtPage :page-key="route => route.fullPath" />
     </div>
+
+    <NuxtPage :page-key="route => route.fullPath" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { RiCalendarEventLine, RiCheckboxCircleLine, RiLink, RiPlayLargeLine, RiToolsLine } from '@remixicon/vue'
 import TabLinks from '~/components/TabLinks.vue'
-import type { HarvesterSource } from '~/types/harvesters'
+import type { HarvesterJob, HarvesterSource } from '~/types/harvesters'
 
 const { t } = useI18n()
 const { $api } = useNuxtApp()
@@ -119,6 +137,13 @@ const { toast } = useToast()
 const route = useRoute()
 const url = computed(() => `/api/1/harvest/source/${route.params.id}`)
 const { data: harvester } = await useAPI<HarvesterSource>(url, { lazy: true })
+const job = ref<HarvesterJob | null>(null)
+watchEffect(async () => {
+  if (!harvester.value) return
+  if (!route.params.jobid) return
+
+  job.value = await $api(`/api/1/harvest/job/${route.params.jobid}`)
+})
 
 const loading = ref(false)
 const run = async () => {

--- a/pages/beta/admin/harvesters/[id]/index.vue
+++ b/pages/beta/admin/harvesters/[id]/index.vue
@@ -108,7 +108,7 @@
                 <AdminContentWithTooltip>
                   <NuxtLinkLocale
                     class="fr-link fr-reset-link"
-                    :href="getHarvesterAdminUrl(harvester)"
+                    :href="getHarvesterJobAdminUrl(harvester, job)"
                   >
                     {{ job.id }}
                   </NuxtLinkLocale>

--- a/utils/harvesters.ts
+++ b/utils/harvesters.ts
@@ -1,5 +1,9 @@
-import type { HarvesterSource } from '~/types/harvesters'
+import type { HarvesterJob, HarvesterSource } from '~/types/harvesters'
 
 export function getHarvesterAdminUrl(harvester: HarvesterSource) {
   return `/beta/admin/harvesters/${harvester.id}`
+}
+
+export function getHarvesterJobAdminUrl(harvester: HarvesterSource, job: HarvesterJob) {
+  return `${getHarvesterAdminUrl(harvester)}/jobs/${job.id}`
 }


### PR DESCRIPTION
This is messier than we want because we cannot have a simple `/harvest-jobs/[id]` page. The API doesn't provide a way to get back to the source from the job ID :-( So we need to be inside the source folder and inheritate the layout which is not exactly what we want…