### PR TITLE
Add matomo tracker for client side only

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,6 +74,12 @@ export default defineNuxtConfig({
       sentry: {
         dsn: '',
       },
+
+      // URL of your matomo host.
+      matomo_host: undefined,
+
+      // Matomo ID of your site. Check the Matomo backend for it
+      matomo_site_id: 1,
     },
   },
 

--- a/plugins/matomo.client.ts
+++ b/plugins/matomo.client.ts
@@ -1,0 +1,19 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  const _paq = (window._paq = window._paq || [])
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView'])
+  _paq.push(['enableLinkTracking']);
+  (function () {
+    const u = nuxtApp.$config.public.matomo_host
+    if (u) {
+      _paq.push(['setTrackerUrl', u + 'matomo.php'])
+      _paq.push(['setSiteId', nuxtApp.$config.public.matomo_site_id])
+      const d = document,
+        g = d.createElement('script'),
+        s = d.getElementsByTagName('script')[0]
+      g.async = true
+      g.src = u + 'matomo.js'
+      s.parentNode.insertBefore(g, s)
+    }
+  })()
+})


### PR DESCRIPTION
This will include a script from stats.data.gouv.fr, adding this information for https://github.com/datagouv/data.gouv.fr/issues/1557