### PR TITLE
Add /beta/admin/reuses/<reuse_id> route

### DIFF
--- a/pages/beta/admin/reuses/[id].vue
+++ b/pages/beta/admin/reuses/[id].vue
@@ -9,30 +9,32 @@
           {{ t('Administration') }}
         </NuxtLinkLocale>
       </li>
-      <li v-if="reuse.organization">
-        <NuxtLinkLocale
-          class="fr-breadcrumb__link"
-          :to="`/beta/admin/organizations/${reuse.organization.id}/profile`"
-        >
-          {{ reuse.organization.name }}
-        </NuxtLinkLocale>
-      </li>
-      <li v-if="reuse.organization">
-        <NuxtLinkLocale
-          class="fr-breadcrumb__link"
-          :to="`/beta/admin/organizations/${reuse.organization.id}/reuses`"
-        >
-          {{ t('Reuses') }}
-        </NuxtLinkLocale>
-      </li>
-      <li v-if="reuse">
-        <a
-          class="fr-breadcrumb__link"
-          aria-current="page"
-        >
-          {{ reuse.title }}
-        </a>
-      </li>
+      <template v-if="reuse">
+        <li v-if="reuse.organization">
+          <NuxtLinkLocale
+            class="fr-breadcrumb__link"
+            :to="`/beta/admin/organizations/${reuse.organization.id}/profile`"
+          >
+            {{ reuse.organization.name }}
+          </NuxtLinkLocale>
+        </li>
+        <li v-if="reuse.organization">
+          <NuxtLinkLocale
+            class="fr-breadcrumb__link"
+            :to="`/beta/admin/organizations/${reuse.organization.id}/reuses`"
+          >
+            {{ t('Reuses') }}
+          </NuxtLinkLocale>
+        </li>
+        <li v-if="reuse">
+          <a
+            class="fr-breadcrumb__link"
+            aria-current="page"
+          >
+            {{ reuse.title }}
+          </a>
+        </li>
+      </template>
     </Breadcrumb>
 
     <div v-if="reuse">

--- a/pages/beta/admin/reuses/[id].vue
+++ b/pages/beta/admin/reuses/[id].vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <Breadcrumb>
+      <li>
+        <NuxtLinkLocale
+          class="fr-breadcrumb__link"
+          to="/beta/admin"
+        >
+          {{ t('Administration') }}
+        </NuxtLinkLocale>
+      </li>
+      <li v-if="reuse.organization">
+        <NuxtLinkLocale
+          class="fr-breadcrumb__link"
+          :to="`/beta/admin/organizations/${reuse.organization.id}/profile`"
+        >
+          {{ reuse.organization.name }}
+        </NuxtLinkLocale>
+      </li>
+      <li v-if="reuse.organization">
+        <NuxtLinkLocale
+          class="fr-breadcrumb__link"
+          :to="`/beta/admin/organizations/${reuse.organization.id}/reuses`"
+        >
+          {{ t('Reuses') }}
+        </NuxtLinkLocale>
+      </li>
+      <li v-if="reuse">
+        <a
+          class="fr-breadcrumb__link"
+          aria-current="page"
+        >
+          {{ reuse.title }}
+        </a>
+      </li>
+    </Breadcrumb>
+
+    <div v-if="reuse">
+      <div class="flex items-center justify-between mb-5">
+        <h1 class="fr-h3 !mb-0">
+          {{ reuse.title }}
+        </h1>
+        <a
+          :href="reuse.page"
+          class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--secondary-grey-500 fr-btn--icon-left fr-icon-eye-line"
+        >
+          {{ t('See the reuse page') }}
+        </a>
+      </div>
+
+      <TabLinks
+        class="mb-5"
+        :links="[
+          { href: getReuseAdminUrl(reuse), label: t('Metadata') },
+          { href: `${getReuseAdminUrl(reuse)}/datasets`, label: t('Datasets') },
+        ]"
+      />
+
+      <NuxtPage
+        :page-key="route => route.fullPath"
+        :reuse
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Reuse } from '@datagouv/components'
+import TabLinks from '~/components/TabLinks.vue'
+
+const { t } = useI18n()
+
+const route = useRoute()
+const url = computed(() => `/api/1/reuses/${route.params.id}`)
+const { data: reuse } = await useAPI<Reuse>(url, { lazy: true })
+</script>

--- a/pages/beta/admin/reuses/[id]/datasets.vue
+++ b/pages/beta/admin/reuses/[id]/datasets.vue
@@ -1,0 +1,7 @@
+<template>
+  <AdminUpdateReuseDatasetsPage />
+</template>
+
+<script setup lang="ts">
+import AdminUpdateReuseDatasetsPage from '~/components/Reuses/AdminUpdateReuseDatasetsPage.vue'
+</script>

--- a/pages/beta/admin/reuses/[id]/index.vue
+++ b/pages/beta/admin/reuses/[id]/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <AdminUpdateReusePage />
+</template>
+
+<script setup lang="ts">
+import AdminUpdateReusePage from '~/components/Reuses/AdminUpdateReusePage.vue'
+</script>

--- a/utils/reuses.ts
+++ b/utils/reuses.ts
@@ -2,12 +2,7 @@ import type { Dataset, Reuse, ReuseType } from '@datagouv/components'
 import type { DatasetSuggest, NewReuseForApi, ReuseForm, ReuseTopic } from '~/types/types'
 
 export function getReuseAdminUrl(reuse: Reuse): string {
-  if (reuse.owner) {
-    return `/beta/admin/me/reuses/${reuse.id}`
-  }
-  else {
-    return `/beta/admin/organizations/${reuse.organization.id}/reuses/${reuse.id}`
-  }
+  return `/beta/admin/reuses/${reuse.id}`
 }
 
 export function toForm(reuse: Reuse, types: Array<ReuseType>, topics: Array<ReuseTopic>): ReuseForm {


### PR DESCRIPTION
Related to https://github.com/datagouv/data.gouv.fr/issues/1648

Add `/beta/admin/reuses/<reuse_id>` route instead of having `organizations/<org_id>` or `me/`.

Should we remove existing pages withing orga or me, ex https://github.com/datagouv/front-end/tree/main/pages/beta/admin/organizations/%5Boid%5D/reuses?
Same for [datasets](https://github.com/datagouv/front-end/tree/main/pages/beta/admin/organizations/%5Boid%5D/datasets).

- [x] Fix current issue due to breadcrumb routing (when accessing from `/organizations/<org_id>/reuses`)