### PR TITLE
fix: new config for seo links

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,6 +28,9 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
+      i18n: {
+        baseUrl: 'https://www.data.gouv.fr/', // NUXT_PUBLIC_I18N_BASE_URL
+      },
       apiBase: 'http://dev.local:7000',
       qualityDescriptionLength: 100,
       searchAutocompleteDebounce: 200,
@@ -129,6 +132,7 @@ export default defineNuxtConfig({
     },
   },
   i18n: {
+    baseUrl: '',
     locales: [
       {
         code: 'en',


### PR DESCRIPTION
New environment variable : NUXT_PUBLIC_I18N_BASE_URL

As per the i18n documentation, it should be the start of fully-qualified URLs e.g. `https://dev.data.gouv.fr` for SEO purpose.