### PR TITLE
Increase node allocated memory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY ./ /app
 
 ENV NODE_OPTIONS=--openssl-legacy-provider
+ENV NODE_OPTIONS=--max_old_space_size=4096
 
 RUN npm install
 RUN echo "$(date)" && \


### PR DESCRIPTION
When I try to build the image locally, I encounter an OOM error
```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

Increasing [max_old_space_size](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-mib) fixes it for me.