### PR TITLE
clean: put config values in nuxt.config.ts and rename config keys

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -23,17 +23,17 @@ app.vueApp.use(datagouv, {
   apiBase: runtimeConfig.public.apiBase,
   devApiKey: runtimeConfig.public.devApiKey,
   staticUrl: runtimeConfig.public.staticUrl,
+  datasetQualityGuideUrl: runtimeConfig.public.datasetQualityGuideUrl,
+  maxJsonPreviewCharSize: runtimeConfig.public.maxJsonPreviewCharSize,
+  maxPdfPreviewByteSize: runtimeConfig.public.maxPdfPreviewByteSize,
+  maxXmlPreviewCharSize: runtimeConfig.public.maxXmlPreviewCharSize,
+  pmtilesViewerBaseUrl: null,
+  schemaValidataUrl: runtimeConfig.public.schemaValidataUrl,
   tabularApiUrl: runtimeConfig.public.tabularApiUrl,
   tabularAllowRemote: true,
-  pmtilesViewerBaseUrl: null,
-  datasetQualityGuideUrl: runtimeConfig.public.datasetQualityGuideUrl,
   customUseFetch: useAPI as UseFetchFunction, // Why this `as` is required?
   textClamp: TextClamp,
   appLink: CdataLink,
-  maxJsonPreviewSize: 1000000, // Maximum size of JSON to preview in characters (~1MB). JSON preview module is partly collapsed by default so we can have a preview for large files.
-  maxPdfPreviewSize: 10000000, // Maximum size of PDF to preview in bytes (10 MB)
-  maxXmlPreviewSize: 100000, // Maximum size of XML to preview in characters (~100KB). XML preview module can NOT be collapsed by default so we should not have a preview for large files.
-  schemaValidataUrl: runtimeConfig.public.schemaValidataUrl,
 })
 
 useHeadSafe({

--- a/datagouv-components/src/components/ResourceAccordion/JsonPreview.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/JsonPreview.client.vue
@@ -96,17 +96,17 @@ const shouldLoadJson = computed(() => {
     return false
   }
 
-  // Check if maxJsonPreviewSize is configured
-  if (!config.maxJsonPreviewSize) {
+  // Check if maxJsonPreviewCharSize is configured
+  if (!config.maxJsonPreviewCharSize) {
     // If no limit is set, don't load unknown files
     return false
   }
 
-  // Convert maxJsonPreviewSize from characters to bytes (rough estimate)
+  // Convert maxJsonPreviewCharSize from characters to bytes (rough estimate)
   // Assuming average 1 byte per character for JSON
-  const maxSizeBytes = config.maxJsonPreviewSize
+  const maxByteSize = config.maxJsonPreviewCharSize
 
-  return size <= maxSizeBytes
+  return size <= maxByteSize
 })
 
 const fetchJsonData = async () => {

--- a/datagouv-components/src/components/ResourceAccordion/PdfPreview.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/PdfPreview.client.vue
@@ -109,9 +109,9 @@ const shouldLoadPdf = computed(() => {
     return false
   }
 
-  // Use maxPdfPreviewSize from config, fallback to 10 MB if not set
-  const maxSizeBytes = config.maxPdfPreviewSize ?? 10_000_000
-  return size <= maxSizeBytes
+  // Use maxPdfPreviewByteSize from config, fallback to 10 MB if not set
+  const maxByteSize = config.maxPdfPreviewByteSize ?? 10_000_000
+  return size <= maxByteSize
 })
 
 const loadPdf = async () => {

--- a/datagouv-components/src/components/ResourceAccordion/XmlPreview.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/XmlPreview.client.vue
@@ -86,17 +86,17 @@ const shouldLoadXml = computed(() => {
     return false
   }
 
-  // Check if maxXmlPreviewSize is configured
-  if (!config.maxXmlPreviewSize) {
+  // Check if maxXmlPreviewCharSize is configured
+  if (!config.maxXmlPreviewCharSize) {
     // If no limit is set, don't load unknown files
     return false
   }
 
-  // Convert maxXmlPreviewSize from characters to bytes (rough estimate)
+  // Convert maxXmlPreviewCharSize from characters to bytes (rough estimate)
   // Assuming average 1 byte per character for XML
-  const maxSizeBytes = config.maxXmlPreviewSize
+  const maxByteSize = config.maxXmlPreviewCharSize
 
-  return size <= maxSizeBytes
+  return size <= maxByteSize
 })
 
 const fetchXmlData = async () => {

--- a/datagouv-components/src/config.ts
+++ b/datagouv-components/src/config.ts
@@ -8,19 +8,19 @@ export type PluginConfig = {
   devApiKey?: string | null
   staticUrl: string
   datasetQualityGuideUrl?: string
+  maxJsonPreviewCharSize?: number  // Maximum size of JSON to preview in characters. JSON preview module is partly collapsed by default so we can have a preview for large files.
+  maxPdfPreviewByteSize?: number // Maximum size of PDF to preview in bytes
+  maxXmlPreviewCharSize?: number // Maximum size of XML to preview in characters. XML preview module can NOT be collapsed by default so we should not have a preview for large files.
+  pmtilesViewerBaseUrl?: string | null // Base URL of a pmtiles viewer (ex: https://pmtiles.io/#url=)
   schemaValidataUrl?: string
   schemaDocumentationUrl?: string
   tabularApiUrl?: string
   tabularApiPageSize?: number
   tabularAllowRemote?: boolean
   tabularApiDataserviceId?: string
-  pmtilesViewerBaseUrl?: string | null // Base URL of a pmtiles viewer (ex: https://pmtiles.io/#url=)
   customUseFetch?: UseFetchFunction | null
   textClamp?: string | Component | null
   appLink?: Component | null
-  maxJsonPreviewSize?: number // Maximum size of JSON to preview in characters
-  maxPdfPreviewSize?: number // Maximum size of PDF to preview in bytes
-  maxXmlPreviewSize?: number // Maximum size of XML to preview in characters
   i18n?: {
     global: {
       mergeLocaleMessage: (locale: string, messages: unknown) => void

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,20 +54,22 @@ export default defineNuxtConfig({
       commitId: undefined,
       banner: undefined,
 
+      title: 'data.gouv.fr',
       apiBase: 'http://dev.local:7000',
       frontBase: 'http://dev.local:3000',
-      staticUrl: 'https://static.data.gouv.fr/static/',
-      devApiKey: undefined,
-
       metricsApi: 'https://metric-api.data.gouv.fr',
+      devApiKey: undefined,
+      staticUrl: 'https://static.data.gouv.fr/static/',
+      maxJsonPreviewCharSize: 1000000, // (~1MB)
+      maxPdfPreviewByteSize: 10000000, // (10 MB)
+      maxXmlPreviewCharSize: 100000, // (~100KB)
+      schemaValidataUrl: 'https://validata.fr',
       tabularApiUrl: 'https://tabular-api.data.gouv.fr',
 
       qualityDescriptionLength: 100,
       searchAutocompleteDebounce: 200,
       searchSirenUrl: 'https://recherche-entreprises.api.gouv.fr/search',
       csvDatasetId: undefined,
-
-      title: 'data.gouv.fr',
 
       // Without www/demo/dev
       baseDomain: 'data.gouv.fr',
@@ -88,7 +90,6 @@ export default defineNuxtConfig({
       guidesCommunityResources: 'https://guides.data.gouv.fr/publier-des-donnees/guide-data.gouv.fr/ressource-communautaire',
       supportUrl: 'https://support.data.gouv.fr/',
       catalogUrl: 'https://guides.data.gouv.fr/autres-ressources-utiles/catalogage-de-donnees-grist',
-      schemaValidataUrl: 'https://validata.fr',
 
       homepagePublishDatasetOnboarding: '/pages/onboarding/producteurs',
       homepagePublishReuseOnboarding: '/pages/onboarding/reutilisateurs',


### PR DESCRIPTION
While working on the codebase I realized that in one of my previous PR I didn't put put config values in the right place, and that my namings for some keys could be confusing.

So this PR does the following basic cleaning:

- Put config values in `nuxt.config.ts` instead of in `app.vue`
- Rename somes config keys to include which unit it refers to avoid confusion
- Reorder some config key/values to increase readability/maintenability