### PR TITLE
Fix tooltip height 100% in layout

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,8 +1,8 @@
 <template>
-  <div id="tooltips" />
   <NuxtLoadingIndicator color="var(--blue-cumulus-main-526)" />
   <NuxtRouteAnnouncer />
   <NuxtLayout>
+    <div id="tooltips" />
     <NuxtPage />
   </NuxtLayout>
 </template>

--- a/datagouv-components/src/components/Toggletip.vue
+++ b/datagouv-components/src/components/Toggletip.vue
@@ -67,22 +67,17 @@ const panelStyle = ref({})
 const calculatePanelPosition = () => {
   nextTick(() => {
     const button = buttonRef.value?.$el || buttonRef.value
-    const tooltips = document.getElementById('tooltips')
 
-    if (!button || !tooltips) {
-      console.warn('Cannot find the button or the tooltips\' teleport target (maybe you forget to add <div id="tooltips" /> in your layout.)')
+    if (!button) {
+      console.error('Cannot find the button of the Toggletip.)')
       return
     }
 
     const buttonRect = button.getBoundingClientRect()
-    const tooltipsRect = tooltips.getBoundingClientRect()
-
-    const relativeX = buttonRect.left - tooltipsRect.left
-    const relativeY = buttonRect.bottom - tooltipsRect.top
 
     panelStyle.value = {
-      left: `${relativeX}px`,
-      top: `${relativeY}px`,
+      left: `${buttonRect.left}px`,
+      top: `${buttonRect.bottom}px`,
     }
   })
 }


### PR DESCRIPTION
We have a `#__nuxt > div { height: 100% }` that triggered on the `#tooltips` div in the layout. Changing the position of the tooltips made me realise that we don't need to do a diff for the absolute position. The tooltip is positionned based on the body and not it's real position.