### PR TITLE
Fix too many requests in ObjectsSelect

### DIFF
--- a/components/ObjectsSelect.vue
+++ b/components/ObjectsSelect.vue
@@ -148,7 +148,7 @@ const suggest = async (query: string): Promise<Array<TSuggest>> => {
   })
 }
 
-watchEffect(async () => {
+watch(selectedSuggest.value, async () => {
   for (const object of selectedSuggest.value) {
     if (object.id in objectsByIds.value) continue
 
@@ -160,7 +160,7 @@ watchEffect(async () => {
       objectsByIds.value[object.id] = await props.fetch(object.id)
     }
   }
-})
+}, { immediate: true })
 
 const selected = computed<Array<T | TSuggest>>(() => {
   return selectedSuggest.value.map((datasetSuggest) => {


### PR DESCRIPTION
Since there is a `object.id in objectsByIds.value`, `watchEffect` was triggering again on `objectsByIds.value[object.id] =` but we don't need to fetch on `objectsByIds` changes, only on `selectedSuggest` ones.

You can test on http://dev.local:3000/admin/reuses/6721fde6ff0522e9cc7ef5d0/datasets

Maybe we could find a way to fetch all objects at once (by passing them from the parent? Because the ObjectsSelect don't have a clear way to do that, but the parent could do a `/api/1/datasest?reuse=xxx`, maybe?)