### PR TITLE
Fix cards width in mobile

### DIFF
--- a/components/Pages/PageShow.vue
+++ b/components/Pages/PageShow.vue
@@ -23,6 +23,7 @@
         <DatasetCardLg
           v-for="dataset in bloc.datasets"
           :key="dataset.id"
+          class="min-w-0"
           :dataset
         />
       </div>
@@ -33,6 +34,7 @@
         <DataserviceCard
           v-for="dataservice in bloc.dataservices"
           :key="dataservice.id"
+          class="min-w-0"
           :dataservice
         />
       </div>
@@ -43,6 +45,7 @@
         <ReuseCard
           v-for="reuse in bloc.reuses"
           :key="reuse.id"
+          class="min-w-0"
           :reuse
         />
       </div>


### PR DESCRIPTION
In mobile, datasets, dataservices and reuses cards were leaking outside the window…

Before

<img width="404" height="1286" alt="image" src="https://github.com/user-attachments/assets/2f116feb-41e8-4e9a-8e47-1a04db3cf205" />

After

<img width="404" height="1286" alt="image" src="https://github.com/user-attachments/assets/9bc1fc19-22d0-4a09-8cee-742204c057d5" />
