### PR TITLE
fix: attempt to fix Sentry config for sourcemaps uploads to be matched

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -14,11 +14,11 @@ jobs:
         shell: bash
         run: |
           # Set RELEASE_VERSION
-          echo "RELEASE_VERSION=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
           # Set ENV based on branch name
           if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-            echo "ENV=dev" >> $GITHUB_ENV
+            echo "ENV=dev.data.gouv.fr" >> $GITHUB_ENV
           fi
 
       - name: Use Node.js

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,9 +2,8 @@ import * as Sentry from '@sentry/nuxt'
 
 Sentry.init({
   dsn: useRuntimeConfig().public.sentry.dsn,
+  release: useRuntimeConfig().public.commitId,
   environment: useRuntimeConfig().public.apiBase.replace(/https?:\/\//, ''),
-
-  // We recommend adjusting this value in production, or using tracesSampler
-  // for finer control
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 0.1, // Adjust this value in production or use tracesSampler for finer control
+  profilesSampleRate: 0.1, // Adjust this value in production
 })


### PR DESCRIPTION
Attempt to fix https://github.com/datagouv/cdata/issues/677.

The issue with sourcemaps in Sentry may have been caused by mismatched release IDs and environments between the CI sourcemaps upload to Sentry and Sentry client error reporting.

- **CI**: Was uploading source maps with 8-char release (`a1b2c3d4`) and env `dev`
- **Client**: Errors were reported with no release number, and env `dev.data.gouv.fr`

**Solution**: 
- Synchronized release format, 7 chars everywhere : in `NUXT_PUBLIC_COMMIT_ID` (which should be used by `release: useRuntimeConfig().public.commitId`, if I'm not mistaken?) and in the CI
- Aligned environment values, using format `dev.data.gouv.fr` in `sentry.client.config.ts` and in the CI

Source maps and errors should now use identical identifiers, potentially enabling proper stack trace deminification in Sentry.

**Also**:
- Added Sentry profiling
