### PR TITLE
test: capture screenshots on failure, do not retry

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,8 +17,6 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
   timeout: 60_0000,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
@@ -29,8 +27,8 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.BASE_URL || 'http://dev.local:3000',
 
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
 
     locale: 'fr-FR',
 


### PR DESCRIPTION
I don't think we need retry right now (tests should work every time…), it slows down the result…

Try to capture screenshots on failure to have a quick view of the problem.

