### PR TITLE
Remove HTML properties in PMTiles popup descriptions

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/Pmtiles.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/Pmtiles.client.vue
@@ -116,7 +116,7 @@ async function displayMap() {
       else {
         const coordinates = e.lngLat
         const description = Object.keys(e.features[0].properties).map((element) => {
-          return `<b>${DOMPurify.sanitize(element)} :</b> ${DOMPurify.sanitize(e.features[0].properties[element])}`
+          return `<b>${DOMPurify.sanitize(element, { USE_PROFILES: { html: false } })} :</b> ${DOMPurify.sanitize(e.features[0].properties[element], { USE_PROFILES: { html: false } })}`
         }).join('<br>')
         popup.setLngLat(coordinates).setHTML(description).addTo(map)
       }


### PR DESCRIPTION
Prevent having properties with HTML contents breaking the description layout.
[Example resource](https://www.data.gouv.fr/datasets/lieux-de-vaccination-contre-la-grippe-pharmacies-sante-fr/?resource_id=479afe3e-a2aa-4519-b509-ba9c106a5576) with broken description.

We were already sanitizing the user content, but we don't want to return HTML tags entirely