### PR TITLE
feat(resource): show "Visiter" as CTA for resource that are URLs

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -92,7 +92,7 @@
       </div>
       <div class="flex items-center buttons">
         <p
-          v-if="resource.format === 'url'"
+          v-if="isResourceUrl"
           class="fr-col-auto fr-ml-3v fr-m-0 z-2"
         >
           <BrandedButton
@@ -370,6 +370,7 @@ import DataStructure from './DataStructure.vue'
 import Preview from './Preview.vue'
 
 const GENERATED_FORMATS = ['parquet', 'pmtiles', 'geojson']
+const URL_FORMATS = ['url', 'doi', 'www:link', ' www:link-1.0-http--link', 'www:link-1.0-http--partners', 'www:link-1.0-http--related', 'www:link-1.0-http--samples']
 
 const props = withDefaults(defineProps<{
   dataset: Dataset | DatasetV2
@@ -512,6 +513,8 @@ const resourceExternalUrl = computed(() => getResourceExternalUrl(props.dataset,
 const resourceContentId = 'resource-' + props.resource.id
 const resourceHeaderId = 'resource-' + props.resource.id + '-header'
 const resourceTitleId = getResourceTitleId(props.resource)
+
+const isResourceUrl = computed(() => URL_FORMATS.includes(props.resource.format))
 </script>
 
 <style scoped>


### PR DESCRIPTION
We currently show this CTA only for resources with `url` as format.

This PR extends the list of resources formats associated with this CTA to known INSPIRE formats.
[This dataset](https://www.data.gouv.fr/datasets/ocs2d-occupation-du-sol-en-2-dimensions-scot-de-lille-mel-ccpc-2005-2015-2020/) would show as:
<img width="1269" height="341" alt="image" src="https://github.com/user-attachments/assets/74e69a03-4774-4947-aecf-ecb5db96406b" />

List of protocol in ISO 19139: https://docs.geonetwork-opensource.org/4.4/annexes/standards/iso19139/#iso19139-elem-gmd-protocol-447dfb15f197f008cd2326a7dab836e8.
