### PR TITLE
fix: double harvest source schedule save

### DIFF
--- a/pages/admin/harvesters/[id]/configuration.vue
+++ b/pages/admin/harvesters/[id]/configuration.vue
@@ -117,7 +117,7 @@ const save = async () => {
   try {
     loading.value = true
 
-    harvester.value = await $api(`/api/1/harvest/source/${harvester.value.id}`, {
+    await $api(`/api/1/harvest/source/${harvester.value.id}`, {
       method: 'PUT',
       body: JSON.stringify(harvesterToApi(harvesterForm.value)),
     })


### PR DESCRIPTION
When removing the schedule of an harvest source, then adding it back directly it wasn't working because the schedule wasn't refresh in the variable.