### PR TITLE
feat: add Matomo event tracking across user interactions

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/Preview.vue
+++ b/datagouv-components/src/components/ResourceAccordion/Preview.vue
@@ -32,6 +32,7 @@
               :href="resource.preview_url"
               :icon="RiExternalLinkFill"
               icon-right
+              @click="trackEvent('Jeux de données', 'Explorer les données', 'Bouton : explorer les données')"
             >
               {{ t("Explorer les données") }}
             </BrandedButton>
@@ -108,6 +109,7 @@ import { RiArrowDownLine, RiArrowUpLine, RiErrorWarningLine, RiExternalLinkFill 
 import Pagination from '../Pagination.vue'
 import { getData, type SortConfig } from '../../functions/tabularApi'
 import { useFormatDate } from '../../functions/dates'
+import { trackEvent } from '../../functions/matomo'
 import type { Resource } from '../../types/resources'
 import { useComponentsConfig } from '../../config'
 import BrandedButton from '../BrandedButton.vue'

--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -103,6 +103,7 @@
             new-tab
             size="xs"
             external
+            @click="trackEvent('Jeux de données', 'Télécharger un fichier', 'Bouton : télécharger un fichier')"
           >
             {{ t('Visiter') }}
           </BrandedButton>
@@ -136,6 +137,7 @@
             size="xs"
             :aria-describedby="resourceTitleId"
             external
+            @click="trackEvent('Jeux de données', 'Télécharger un fichier', 'Bouton : télécharger un fichier')"
           >
             <span class="sr-only">{{ t('Télécharger la liste au format ') }}</span>{{ format }}
           </BrandedButton>
@@ -259,6 +261,7 @@
                       class="fr-link no-icon-after"
                       rel="ugc nofollow noopener"
                       target="_blank"
+                      @click="trackEvent('Jeux de données', 'Télécharger un fichier', 'Bouton : télécharger un fichier')"
                     >
                       <component
                         :is="config.textClamp"
@@ -279,6 +282,7 @@
                       :href="resource.latest"
                       class="fr-link"
                       rel="ugc nofollow noopener"
+                      @click="trackEvent('Jeux de données', 'Télécharger un fichier', `Bouton : format ${resource.format}`)"
                     >
                       <span>{{ t('Format {format}', { format: resource.format }) }}<span v-if="resourceFilesize"> - {{ filesize(resourceFilesize) }}</span></span>
                     </a>
@@ -305,6 +309,7 @@
                         :href="generatedFormat.url"
                         class="fr-link"
                         rel="ugc nofollow noopener"
+                        @click="trackEvent('Jeux de données', 'Télécharger un fichier', `Bouton : format ${generatedFormat.format}`)"
                       >
                         <span>{{ t('Format {format}', { format: generatedFormat.format }) }}<span v-if="generatedFormat.size"> - {{ filesize(generatedFormat.size) }}</span></span>
                       </a>
@@ -445,10 +450,10 @@ const toggle = () => {
   open.value = !open.value
 
   if (open.value) {
-    trackEvent(['Open resource', props.resource.id])
+    trackEvent('Open resource', props.resource.id)
   }
   else {
-    trackEvent(['Close resource', props.resource.id])
+    trackEvent('Close resource', props.resource.id)
   }
 }
 
@@ -485,13 +490,13 @@ const switchTab = (index: number) => {
   if (!option) {
     return
   }
-  trackEvent(['View resource tab', props.resource.id, option.label])
+  trackEvent('View resource tab', props.resource.id, option.label)
 
   if (option.key === 'data') {
-    trackEvent(['Show preview', props.resource.id])
+    trackEvent('Show preview', props.resource.id)
   }
   if (option.key === 'data-structure') {
-    trackEvent(['Show data structure', props.resource.id])
+    trackEvent('Show data structure', props.resource.id)
   }
 }
 

--- a/datagouv-components/src/functions/matomo.ts
+++ b/datagouv-components/src/functions/matomo.ts
@@ -1,4 +1,23 @@
-export function trackEvent(values: Array<unknown>): void {
-  // @ts-expect-error Matomo is not typed
-  globalThis._paq?.push(['trackEvent', ...values])
+export type MatomoTracker = {
+  // https://developer.matomo.org/api-reference/tracking-javascript
+  enableLinkTracking(bool: boolean): void
+  setReferrerUrl(url: string): void
+  trackPageView(title?: string): void
+  trackEvent(category: string, action: string, name?: string): void
+  trackSiteSearch(keyword: string, category: string, resultsCount: number): void
+  trackLink(url: string, linkType: string): void
+  // More TODO
+}
+
+// inspired by https://github.com/AmazingDreams/vue-matomo/blob/master/src/index.js
+export function getMatomo() {
+  // @ts-expect-error Matomo might be defined by project
+  return window?.Matomo?.getTracker() as MatomoTracker | undefined
+}
+
+export function trackEvent(category: string, action: string, name?: string): void {
+  const matomo = getMatomo()
+  if (matomo) {
+    matomo.trackEvent(category, action, name)
+  }
 }

--- a/pages/dataservices/[did].vue
+++ b/pages/dataservices/[did].vue
@@ -236,6 +236,7 @@
               :icon="RiExternalLinkLine"
               icon-right
               external
+              @click="$matomo.trackEvent('API', `Accéder à l'api`, 'Bouton : documentation métier')"
             >
               {{ $t('Documentation métier') }}
             </BrandedButton>
@@ -247,7 +248,7 @@
             <button
               type="button"
               class="min-h-[42px] w-full flex items-center justify-between"
-              @click="openSwagger = !openSwagger"
+              @click="showSwagger"
             >
               <div class="text-datagouv-dark font-bold text-xl">
                 {{ $t('Swagger') }}
@@ -301,6 +302,7 @@ import ReportModal from '~/components/Spam/ReportModal.vue'
 const config = useRuntimeConfig()
 const route = useRoute()
 const { formatDate } = useFormatDate()
+const { $matomo } = useNuxtApp()
 
 const url = computed(() => `/api/1/dataservices/${route.params.did}/`)
 const { data: dataservice, status } = await useAPI<Dataservice>(url, { redirectOn404: true, redirectOnSlug: 'did' })
@@ -315,6 +317,13 @@ useSeoMeta({
 await useJsonLd('dataservice', route.params.did)
 
 const openSwagger = ref(false)
+
+function showSwagger() {
+  openSwagger.value = !openSwagger.value
+  if (openSwagger.value) {
+    $matomo.trackEvent('API', `Accéder à l'api`, 'Bouton : ouvrir swagger')
+  }
+}
 
 const accessAudiences = computed(() => (['local_authority_and_administration', 'company_and_association', 'private'] as Array<DataserviceAccessAudienceType>)
   .map(type => dataservice.value.access_audiences.find(a => a.role === type))

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -34,7 +34,8 @@
             :icon="RiExternalLinkFill"
             icon-right
             size="xs"
-            target="blank"
+            new-tab
+            @click="$matomo.trackEvent('Jeux de données', 'Explorer les données', 'Bouton : explorer les données')"
           >
             {{ $t("Explorer les données") }}
           </BrandedButton>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -36,6 +36,7 @@
           <BrandedButton
             href="/datasets"
             class="w-full sm:w-auto"
+            @click="$matomo.trackEvent('Homepage', `Découvrir les données`, 'Bouton : découvrez les jeux de données')"
           >
             {{ $t('Découvrez les jeux de données') }}
           </BrandedButton>
@@ -43,6 +44,7 @@
             href="/reuses"
             color="primary-soft"
             class="w-full sm:w-auto"
+            @click="$matomo.trackEvent('Homepage', `Découvrir les réutilisation`, 'Bouton : explorez les réutilisations de données')"
           >
             {{ $t('Explorez les réutilisations de données') }}
           </BrandedButton>

--- a/pages/reuses/[rid].vue
+++ b/pages/reuses/[rid].vue
@@ -30,6 +30,7 @@
               :href="reuse.url"
               :new-tab="true"
               size="xs"
+              @click="$matomo.trackEvent('Réutilisation', `Voir la réutilisation`, 'Bouton :  voir la reutilisation')"
             >
               {{ $t('Voir la réutilisation') }}
             </BrandedButton>
@@ -131,6 +132,7 @@
                 size="xs"
                 :href="reuse.url"
                 :new-tab="true"
+                @click="$matomo.trackEvent('Réutilisation', `Voir la réutilisation`, 'Bouton : voir la reutilisation')"
               >
                 {{ $t('Voir la réutilisation') }}
               </BrandedButton>


### PR DESCRIPTION
## Summary
This PR implements comprehensive Matomo event tracking for key user actions across the application, improving analytics visibility for dataset exploration, API access, and reuse interactions.

## Technical Implementation

### New Matomo tracking infrastructure
- Refactored `trackEvent` function in `datagouv-components/src/functions/matomo.ts`:
  - Changed signature from array-based to explicit parameters: `trackEvent(category, action, name?)`
  - Added proper TypeScript types for `MatomoTracker`
  - Implemented `getMatomo()` helper function
- Exposed `trackEvent` in the Nuxt plugin for global access via `$matomo.trackEvent()`

### Events tracked

**Homepage (`pages/index.vue`)**
- "Découvrez les jeux de données" button → `Homepage / Découvrir les données`
- "Explorez les réutilisations de données" button → `Homepage / Découvrir les réutilisation`

**Dataset pages (`pages/datasets/[did].vue`, `datagouv-components/src/components/ResourceAccordion/`)**
- "Explorer les données" buttons → `Jeux de données / Explorer les données`
- Download buttons → `Jeux de données / Télécharger un fichier` (with format details)

**API/Dataservices page (`pages/dataservices/[did].vue`)**
- "Documentation métier" button → `API / Accéder à l'api`
- Swagger accordion toggle → `API / Accéder à l'api`

**Reuse pages (`pages/reuses/[rid].vue`)**
- "Voir la réutilisation" buttons → `Réutilisation / Voir la réutilisation`

## Testing to do on dev
- [ ] Test each tracked interaction manually
- [ ] Verify events appear in Matomo dashboard with correct category/action/name