### PR TITLE
Fix accept-language header parsing

### DIFF
--- a/datagouv-components/src/composables/useTranslation.ts
+++ b/datagouv-components/src/composables/useTranslation.ts
@@ -18,7 +18,7 @@ function detectLanguage(): string {
     const header = useRequestHeader?.('accept-language')
     const acceptLanguage = header
     if (acceptLanguage) {
-      const primaryLang = acceptLanguage.split(',')[0]!.split('-')[0]!.toLowerCase()
+      const primaryLang = acceptLanguage.split(';')[0]!.split(',')[0]!.split('-')[0]!.toLowerCase()
       return primaryLang
     }
   }


### PR DESCRIPTION
Currently, it wrongly parses accept language such as `accept-language: fr;q=0.7`.

This leads to a query with a broken lang made to the backend, example:
```
curl "https://www.data.gouv.fr/api/1/spatial/zones/suggest/?q=country&lang=ru%3Bq%3D0.8"
```

Fix https://errors.data.gouv.fr/organizations/sentry/issues/269453/?environment=data.gouv.fr&project=12&query=&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=2 or https://errors.data.gouv.fr/organizations/sentry/issues/268429/?environment=data.gouv.fr&project=12&query=&referrer=issue-stream&sort=date&statsPeriod=7d&stream_index=0.

In the case of a call to `api/2/datasets`, `lang` is used for granularities translations when using `X-Get-Datasets-Full-Objects` header.

I wonder if we should validate the resulting lang since we also [have errors](https://errors.data.gouv.fr/organizations/sentry/issues/269453/?environment=data.gouv.fr&project=12&query=&referrer=issue-stream&statsPeriod=7d&stream_index=0) where `lang=*`.