### PR TITLE
Display udata and cdata version in footer

### DIFF
--- a/components/SiteFooter/SiteFooter.vue
+++ b/components/SiteFooter/SiteFooter.vue
@@ -194,7 +194,7 @@
                     class="fr-footer__top-link"
                     :title="site && site.version ? $t('Version {version}', { version: site.version }) : undefined"
                   >
-                    {{ $t('Moteur open source : udata') }}
+                    {{ $t('Moteur open source : udata ({version})', { version: site.version }) }}
                   </a>
                 </li>
                 <li>
@@ -203,7 +203,7 @@
                     :title="config.public.commitId ? $t('Version {version}', { version: config.public.commitId }) : undefined"
                     class="fr-footer__top-link"
                   >
-                    {{ $t('Interface utilisateur de data.gouv.fr : cdata') }}
+                    {{ $t('Interface utilisateur de data.gouv.fr : cdata ({version})', { version: config.public.commitId }) }}
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
Today it's only added as title and require hovering to show it (without being able to copy the value for example)