### PR TITLE
fix: useRoute() in middleware

### DIFF
--- a/composables/useCurrentOwned.ts
+++ b/composables/useCurrentOwned.ts
@@ -1,13 +1,35 @@
 import type { Organization, User } from '@datagouv/components-next'
 import { keyBy } from 'lodash-es'
 
-export function useCurrentOwned() {
+/**
+ * Composable for setters only - can be used in middlewares
+ * because it doesn't use useRoute()
+ */
+export function useCurrentOwnedSetters() {
   const me = useMaybeMe()
-  const route = useRoute()
 
   const organizations = useState('organizations', () => keyBy(me.value?.organizations, org => org.id))
   const users = useState<Record<string, User | Me>>('users', () => (me.value?.id ? { [me.value.id]: me.value } : {}))
   const currentOwnedId = useState<{ organization: string } | { user: string } | null>('currentOrganizationId', () => null)
+
+  const setCurrentOrganization = (organization: Organization) => {
+    if (currentOwnedId.value && 'organization' in currentOwnedId.value && currentOwnedId.value.organization === organization.id) return
+    currentOwnedId.value = { organization: organization.id }
+    organizations.value[organization.id] = organization
+  }
+  const setCurrentUser = (user: User) => {
+    if (currentOwnedId.value && 'user' in currentOwnedId.value && currentOwnedId.value.user === user.id) return
+    currentOwnedId.value = { user: user.id }
+    users.value[user.id] = user
+  }
+
+  return { users, organizations, currentOwnedId, setCurrentOrganization, setCurrentUser }
+}
+
+export function useCurrentOwned() {
+  const { users, organizations, currentOwnedId, setCurrentOrganization, setCurrentUser } = useCurrentOwnedSetters()
+  const me = useMaybeMe()
+  const route = useRoute()
 
   const currentOrganization = computed(() => {
     if (route.params.oid) {
@@ -41,17 +63,6 @@ export function useCurrentOwned() {
 
     return users.value[currentOwnedId.value.user] || null
   })
-
-  const setCurrentOrganization = (organization: Organization) => {
-    if (currentOwnedId.value && 'organization' in currentOwnedId.value && currentOwnedId.value.organization === organization.id) return
-    currentOwnedId.value = { organization: organization.id }
-    organizations.value[organization.id] = organization
-  }
-  const setCurrentUser = (user: User) => {
-    if (currentOwnedId.value && 'user' in currentOwnedId.value && currentOwnedId.value.user === user.id) return
-    currentOwnedId.value = { user: user.id }
-    users.value[user.id] = user
-  }
 
   return { users, organizations, currentOrganization, currentUser, setCurrentOrganization, setCurrentUser }
 }

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -52,7 +52,7 @@ export const loadMe = async (meState: Ref<Me | null | undefined>) => {
   const cookie = useRequestHeader('cookie')
 
   const token = useToken()
-  const { setCurrentOrganization, setCurrentUser } = useCurrentOwned()
+  const { setCurrentOrganization, setCurrentUser } = useCurrentOwnedSetters()
 
   const headers: Record<string, string> = {}
 


### PR DESCRIPTION
```
ssr:warn [nuxt] Calling `useRoute` within middleware may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old
 routes. 
  at .nuxt/dev/sentry.server.config.mjs
  at Object.log (.nuxt/dev/sentry.server.config.mjs)
  at useCurrentOwned (composables/useCurrentOwned.ts)
  at loadMe (utils/auth.ts)
```