### PR TITLE
fix: CdataLink props conflicts

### DIFF
--- a/components/CdataLink.vue
+++ b/components/CdataLink.vue
@@ -1,24 +1,16 @@
 <template>
   <NuxtLink
-    v-bind="{ ...filteredProps, to, href }"
+    v-bind="{ ...attrs, to, href }"
   ><slot /></NuxtLink>
 </template>
 
 <script setup lang="ts">
 import type { NuxtLinkProps } from '#app'
 
-const props = defineProps<NuxtLinkProps>()
+const props = defineProps<Pick<NuxtLinkProps, 'to' | 'href' | 'external'>>()
+const attrs = useAttrs()
 
 const absoluteUrlToRelative = useAbsoluteUrlToRelative()
-
-const filteredProps = computed(() => {
-  // Si prefetch et noPrefetch sont tous les deux définis, on ignore noPrefetch
-  if (props.prefetch !== undefined && props.noPrefetch !== undefined) {
-    const { noPrefetch, ...rest } = props
-    return rest
-  }
-  return props
-})
 
 const to = computed(() => {
   if (!props.to) return props.to


### PR DESCRIPTION
really fix https://github.com/datagouv/cdata/pull/783

because I have "[NuxtLink] `noRel` and `rel` cannot be used together. `rel` will be ignored." after this first PR.