### PR TITLE
fix: hide preview button for org editors

### DIFF
--- a/pages/admin/harvesters/[id]/configuration.vue
+++ b/pages/admin/harvesters/[id]/configuration.vue
@@ -8,6 +8,7 @@
     <template #button>
       <div class="flex items-center space-x-4">
         <ModalWithButton
+          v-if="isOrgAdmin"
           :title="$t('Prévisualiser')"
           size="fullscreen"
           @open="preview"
@@ -95,14 +96,18 @@ import DescribeHarvester from '~/components/Harvesters/DescribeHarvester.vue'
 import JobPage from '~/components/Harvesters/JobPage.vue'
 import PreviewLoader from '~/components/Harvesters/PreviewLoader.vue'
 import type { HarvesterForm, HarvesterJob, HarvesterSource } from '~/types/harvesters'
+import { isUserOrgAdmin, useMe } from '~/utils/auth'
 
 const route = useRoute()
 const { $api } = useNuxtApp()
 const { t } = useTranslation()
 const { toast } = useToast()
+const me = useMe()
 
 const sourceUrl = computed(() => `/api/1/harvest/source/${route.params.id}`)
 const { data: harvester, refresh } = await useAPI<HarvesterSource>(sourceUrl, { redirectOn404: true })
+
+const isOrgAdmin = computed(() => !harvester.value.organization || isUserOrgAdmin(me.value, harvester.value.organization))
 
 const loading = ref(false)
 

--- a/pages/admin/organizations/[oid]/members.vue
+++ b/pages/admin/organizations/[oid]/members.vue
@@ -302,6 +302,7 @@ import SearchableSelect from '~/components/SearchableSelect.vue'
 import AdminMembershipRequest from '~/components/AdminMembershipRequest/AdminMembershipRequest.vue'
 import AdminBreadcrumb from '~/components/Breadcrumbs/AdminBreadcrumb.vue'
 import BreadcrumbItem from '~/components/Breadcrumbs/BreadcrumbItem.vue'
+import { isUserOrgAdmin, useMe } from '~/utils/auth'
 
 const config = useRuntimeConfig()
 const { t } = useTranslation()
@@ -333,7 +334,7 @@ const refreshAll = async () => {
   ])
 }
 
-const isOrgAdmin = computed(() => isMeAdmin() || (organization && organization.value.members.some(member => member.user.id === me.value.id && member.role === 'admin')))
+const isOrgAdmin = computed(() => isUserOrgAdmin(me.value, organization.value))
 
 const newRole = ref<MemberRole | null>(null)
 const { data: roles } = await useAPI<Array<{ id: MemberRole, label: string }>>('/api/1/organizations/roles/', { lazy: true })

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -43,6 +43,12 @@ export function isMeAdmin(): boolean {
   return isAdmin(me.value)
 }
 
+export function isUserOrgAdmin(me: Me | null | undefined, organization: Organization | null | undefined): boolean {
+  if (isAdmin(me)) return true
+  if (!me || !organization) return false
+  return organization.members.some(member => member.user.id === me.id && member.role === 'admin')
+}
+
 export const loadMe = async (meState: Ref<Me | null | undefined>) => {
   // Here we cannot use the `useAPI` composable because
   // we don't want the classic error management that redirect


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/273718/?alert_rule_id=29&alert_timestamp=1764149434391&alert_type=email&environment=www.data.gouv.fr&notification_uuid=2fa8e039-5ff1-4e13-8209-21ab8bbbf7c8&project=30&referrer=alert_email

Preview is only enabled for org admins in udata.

Require https://github.com/datagouv/cdata/pull/793 because `.members` is not available on `source.organization`