### PR TITLE
Get last update for native PMTiles

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/Pmtiles.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/Pmtiles.client.vue
@@ -89,7 +89,7 @@ const pmtilesViewerUrl = computed(() => {
 const lastUpdate = computed(() => {
   if (props.resource.extras['analysis:parsing:pmtiles_url'])
     return formatDate(props.resource.extras['analysis:parsing:finished_at'] as string | undefined)
-  return formatDate(props.resource.last_modified as string | undefined)
+  return formatDate(props.resource.last_modified)
 })
 
 const container = useTemplateRef('containerRef')


### PR DESCRIPTION
Fixes missing last update under map preview ([example](https://www.data.gouv.fr/datasets/carte-des-risques-retrait-gonflement-des-argiles/#/resources/b5b6b6d8-82ee-48e9-b3f5-7c3698f51e59))