### PR TITLE
fix: borders and aspect ratio on mobile for onboarding pages

### DIFF
--- a/components/Onboarding/OnboardingFeatureCard.vue
+++ b/components/Onboarding/OnboardingFeatureCard.vue
@@ -3,7 +3,7 @@
     <!-- Grande carte : image 320px + padding 60px top/bottom -->
     <div
       v-if="image && size === 'large'"
-      class="rounded-t overflow-hidden flex items-center justify-center py-8 md:py-[60px] px-4 bg-gradient-to-b"
+      class="rounded-t overflow-hidden flex items-center justify-center py-8 md:py-[60px] px-4 bg-gradient-to-b border-b border-gray-default"
       :class="gradientClass"
     >
       <NuxtImg
@@ -13,16 +13,16 @@
         loading="lazy"
       />
     </div>
-    <!-- Petite carte : container = padding top 30px + image -->
+    <!-- Petite carte : container avec aspect-ratio, image proportionnelle -->
     <div
       v-if="image && size === 'small'"
-      class="rounded-t overflow-hidden min-h-[190px] md:min-h-[240px] pl-5 md:pl-[30px] flex items-end justify-end bg-gradient-to-b"
+      class="rounded-t overflow-hidden aspect-[378/240] pl-[8%] flex items-end justify-end bg-gradient-to-b border-b border-gray-default"
       :class="gradientClass"
     >
       <NuxtImg
         :src="image"
         alt=""
-        class="w-[260px] md:w-[348px] h-auto object-contain object-right-bottom mt-5 md:mt-[30px]"
+        class="w-[92%] h-auto translate-x-px translate-y-px"
         loading="lazy"
       />
     </div>


### PR DESCRIPTION
- [x] missing border between image and text
- [x] double borders between image and card (translate 1px to hide the image border)
- [x] responsive aspect ratio of card image section