### PR TITLE
fix: onboarding images not showing

### DIFF
--- a/components/Onboarding/OnboardingFeatureCard.vue
+++ b/components/Onboarding/OnboardingFeatureCard.vue
@@ -22,8 +22,7 @@
       <img
         :src="image"
         alt=""
-        class="w-[92%] translate-x-px translate-y-px"
-        loading="lazy"
+        class="w-[92%] h-auto translate-x-px translate-y-px"
       >
     </div>
     <div class="p-4 flex flex-col flex-1">


### PR DESCRIPTION
I don't understand why this break… lazy image and `h-auto` is not working as expected… Maybe Nuxt is doing something special? But I use an `img` tag and not a `NuxtImg` so I don't know…