### PR TITLE
feat(datasets): add Atom feed link to search page

### DIFF
--- a/components/Datasets/SearchPage.vue
+++ b/components/Datasets/SearchPage.vue
@@ -327,10 +327,10 @@ const params = useUrlSearchParams<DatasetSearchParams>('history', {
   removeFalsyValues: true,
 })
 
-const nonFalsyParams = computed(() => {
+const nonFalsyParams = computed<DatasetSearchParams>(() => {
   const filteredParams = Object.entries(toValue(params)).filter(([_k, v]) => v)
   const propsParams = props.organization ? { organization: props.organization.id } : {}
-  return { ...propsParams, ...Object.fromEntries(filteredParams), page_size: pageSize }
+  return { ...propsParams, ...Object.fromEntries(filteredParams) as DatasetSearchParams, page_size: pageSize.toFixed(0) }
 })
 
 const atomFeedUrl = computed(() => {


### PR DESCRIPTION
Add a link to the datasets Atom feed on the search page. The link includes current search filters, allowing users to subscribe to filtered search results via their RSS reader.

Requires opendatateam/udata#3578 for filter support on the Atom endpoint.