### PR TITLE
refactor(albert): migrate from albert-small to openweight-small

### DIFF
--- a/server/routes/nuxt-api/albert/generate-short-description.post.ts
+++ b/server/routes/nuxt-api/albert/generate-short-description.post.ts
@@ -67,12 +67,11 @@ export default defineEventHandler(async (event) => {
       },
     ]
 
-    // As of 2025/08, models available for text generation:
-    // - albert-small
-    // - AgentPublic/albert-spp-8b
-    // - albert-code-beta
-    // - albert-ministral
-    const response = await createChatCompletion(messages, 'albert-small', albertConfig) as ChatResponse
+    // Models available for text generation:
+    // - openweight-small (replaces albert-small)
+    // - openweight-medium (replaces albert-large)
+    // - openweight-large
+    const response = await createChatCompletion(messages, 'openweight-small', albertConfig) as ChatResponse
     const generatedDescriptionShort = response.choices?.[0]?.message?.content || ''
 
     // Ensure the description doesn't exceed maxChars

--- a/server/routes/nuxt-api/albert/generate-tags.post.ts
+++ b/server/routes/nuxt-api/albert/generate-tags.post.ts
@@ -76,12 +76,11 @@ export default defineEventHandler(async (event) => {
       },
     ]
 
-    // As of 2025/08, models available for text generation:
-    // - albert-small
-    // - AgentPublic/albert-spp-8b
-    // - albert-code-beta
-    // - albert-ministral
-    const response = await createChatCompletion(messages, 'albert-small', albertConfig) as ChatResponse
+    // Models available for text generation:
+    // - openweight-small (replaces albert-small)
+    // - openweight-medium (replaces albert-large)
+    // - openweight-large
+    const response = await createChatCompletion(messages, 'openweight-small', albertConfig) as ChatResponse
     const generatedTags = response.choices?.[0]?.message?.content || ''
 
     // Parse the comma-separated tags and clean them


### PR DESCRIPTION
Update model references to use the new openweight-* naming convention as part of Albert API migration. The albert-small alias is being deprecated and will stop working on 2026-02-15.

- Replace albert-small with openweight-small in generate-tags
- Replace albert-small with openweight-small in generate-short-description
- Update comments to reflect new model naming convention

Original message from the Etalab team on Tchap:

# La gamme de modèles d'Albert API évolue !

D'une part, nous abandonnons les alias `albert-*`, qui manquent de clarté, pour utiliser des alias du type `openweight-*` ;

D'autre part, nous mettons à jour certains des modèles mis à disposition via Albert API, à la lumière de récentes analyses de performance, et pour mieux se rapprocher de l'état de l'art sur la langue française ;

Enfin, nous supprimons la fonctionnalité de recherche web.

## Voici les modèles qui vous seront proposés dès cette fin d'année :

- `openweight-large` ==> `openai/gpt-oss-120b`
- `openweight-medium` ==> `mistralai/Mistral-Small-3.2-24B-Instruct-2506` (l'actuel `albert-large`)
- `openweight-small` ==> `mistralai/Ministral-3-8B-Instruct-2512`
- `openweight-embeddings` ==> `BAAI/bge-m3` (l'actuel `embeddings-small`)
- `openweight-rerank` ==> `BAAI/bge-reranker-m3` (l'actuel `rerank-small`)
- `openweight-audio` ==> `openai/whisper-large-v3` (l'actuel `audio-large`)
- `openweight-code` ==> `Qwen/Qwen3-Coder-30B-A3B-Instruct`

Vous noterez que nous décidons ainsi de passer de 2 gammes de modèles texte (large et small) à 3 gammes (small / medium / large), pour mieux refléter les dernières évolutions en terme de modèles à poids ouverts.

## Processus de migration

Dès aujourd'hui, les nouveaux modèles font leur apparition sur l'API.

Jusqu'au 15 février 2026, les anciens modèles et alias cohabiteront avec les nouveaux modèles et nouveaux alias, pour vous permettre de faire la mise à jour au sein de vos produits :

- `openweight-large` pointera vers `openai/gpt-oss-120b`
- `openweight-medium` et `albert-large` pointeront vers `mistralai/Mistral-Small-3.2-24B-Instruct-2506`
- `albert-small` pointera vers `meta-llama/Llama-3.1-8B-Instruct`
- `openweight-small` pointera vers `mistralai/Ministral-3-8B-Instruct-2512`
- etc.

⚠️ **Au 15 février 2026, les alias `albert-*` ne fonctionneront plus.**

⚠️ **Au 15 février 2026, la recherche web ne fonctionnera plus.**

## Ce que vous devez changer pendant la période de transition (15/12/25 au 15/02/26)

⚠️ **Ces changements sont à réaliser impérativement avant le 15/02, pour éviter une disruption de vos services.**

### Si vous utilisez `albert-large` :

- Changez pour `openweight-medium` si vous voulez continuer à utiliser le même modèle ;
- Changez pour `openweight-large` si vous voulez bénéficier d'un plus large modèle (attention, celui-ci n'a pas de capacités multimodales).

### Si vous utilisez `albert-small` :

- Changez pour `openweight-small`

### Si vous utilisez `embeddings-small`, `rerank-small` ou `audio-large` :

- Changez pour `openweight-embeddings`, `openweight-rerank` ou `openweight-audio`

### Si vous utilisez la recherche web :

Contactez nos équipes pour un accompagnement vers une autre solution, avant le 15/02.