### PR TITLE
feat: add test on quality tooltip

### DIFF
--- a/datagouv-components/src/components/DatasetQualityTooltipContent.vue
+++ b/datagouv-components/src/components/DatasetQualityTooltipContent.vue
@@ -52,7 +52,7 @@
       class="pb-0"
     />
   </ul>
-  <div class="fr-grid-row fr-grid-row--right not-enlarged">
+  <div class="fr-grid-row fr-grid-row--right">
     <a
       :href="config.datasetQualityGuideUrl"
       target="_blank"

--- a/tests/datasets/[did].spec.ts
+++ b/tests/datasets/[did].spec.ts
@@ -128,3 +128,39 @@ test('resources are displayed and accordion expands', async ({ page }) => {
   // Verify it's now expanded
   await expect(firstAccordion).toHaveAttribute('aria-expanded', 'true')
 })
+
+test('quality tooltip displays content and link is clickable', async ({ page, context }) => {
+  await page.goto(
+    '/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/',
+  )
+
+  const qualityButton = page.getByRole('button', { name: 'Qualité des métadonnées' }).first()
+  await expect(qualityButton).toBeVisible()
+
+  await qualityButton.click()
+
+  // Target the tooltip panel specifically
+  const tooltip = page.locator('#tooltips')
+
+  // Verify tooltip content (actual data from seed)
+  await expect(tooltip.getByText('Qualité des métadonnées :')).toBeVisible()
+  await expect(tooltip.getByText('Description des données renseignée')).toBeVisible()
+  await expect(tooltip.getByText('Fichiers documentés')).toBeVisible()
+  await expect(tooltip.getByText('Licence non renseignée')).toBeVisible()
+  await expect(tooltip.getByText('Fréquence de mise à jour non respectée')).toBeVisible()
+  await expect(tooltip.getByText('Formats de fichiers standards')).toBeVisible()
+  await expect(tooltip.getByText('Couverture temporelle renseignée')).toBeVisible()
+  await expect(tooltip.getByText('Couverture spatiale non renseignée')).toBeVisible()
+  await expect(tooltip.getByText('Tous les fichiers sont disponibles')).toBeVisible()
+
+  // Verify link is clickable
+  const learnMoreLink = tooltip.getByRole('link', { name: /En savoir plus sur cet indicateur/i })
+  await expect(learnMoreLink).toBeVisible()
+
+  const [newPage] = await Promise.all([
+    context.waitForEvent('page'),
+    learnMoreLink.click(),
+  ])
+
+  await expect(newPage).toHaveURL(/guides/)
+})


### PR DESCRIPTION
The tooltip is teleported outside the card so the `not-enlarged` is not require anymore (and `not-enlarged` was broken anyway following https://github.com/datagouv/cdata/pull/829)