### PR TITLE
fix: allow CORS requests for oembeds

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -199,6 +199,7 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
+    '/nuxt-api/oembed': { cors: true },
     // @ts-expect-error ssr option is valid but not in Nuxt types (see https://github.com/nuxt/nuxt/issues/15199)
     '/*/organizations/': { ssr: true },
     // @ts-expect-error ssr option is valid but not in Nuxt types


### PR DESCRIPTION
Fix https://github.com/orgs/datagouv/projects/3?pane=issue&itemId=151991815&issue=datagouv%7Cdata.gouv.fr%7C1937