### PR TITLE
feat: add helper tooltip to display why suggest tags button is not available

### DIFF
--- a/components/Datasets/DescribeDataset.vue
+++ b/components/Datasets/DescribeDataset.vue
@@ -393,7 +393,6 @@
                 color="primary"
                 :icon="RiSparklingLine"
                 :loading="isGeneratingTags"
-                :disabled="!!tagsSuggestionDisabledMessage"
                 @click="handleAutoCompleteTags(MAX_TAGS_NB)"
               >
                 <template v-if="isGeneratingTags">


### PR DESCRIPTION
## Add tooltip to explain why tag suggestion button is disabled

Adds a tooltip to the tag suggestion button in DescribeDataset.vue to explain why it's disabled, matching the behavior of the short description suggestion button and of https://github.com/datagouv/cdata/pull/884.

The tooltip shows:

- Missing fields (title, description) when the button is disabled
- Maximum tags reached message when 5 tags are already present

This improves UX by clarifying why the feature is unavailable.

