### PR TITLE
feat(dataset): banner for ecologie indicators

### DIFF
--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -338,6 +338,24 @@
                   </template>
                 </TranslationT>
               </SimpleBanner>
+              <SimpleBanner
+                v-if="
+                  'ecospheres-indicateurs' in dataset.extras
+                "
+                type="primary-frame"
+              >
+                <TranslationT
+                  keypath="Consulter ce jeu de données sur {link} pour bénéficier d'informations supplémentaires : métadonnées enrichies, visualisations, etc."
+                  tag="p"
+                  class="!m-0 text-sm"
+                >
+                  <template #link>
+                    <CdataLink :href="`https://${config.public.baseUrl.includes('demo') ? 'demo.': ''}ecologie.data.gouv.fr/indicators/${dataset.id}`">
+                      ecologie.data.gouv.fr
+                    </CdataLink>
+                  </template>
+                </TranslationT>
+              </SimpleBanner>
             </dl>
           </div>
         </div>


### PR DESCRIPTION
Add a banner for ecologie.data.gouv.fr's indicators, similar to the one for transport.data.gouv.fr.

<img width="1014" height="577" alt="Capture d’écran 2026-01-27 à 14 54 51" src="https://github.com/user-attachments/assets/67cd692e-4508-4bce-8b9d-02156705a9a3" />

NB: won't work properly on dev.data.gouv.fr, but no need very extra complexity IMO.

Fix https://github.com/ecolabdata/ecospheres/issues/871