### PR TITLE
feat: better Albert API error logging for quick debugging

### DIFF
--- a/server/utils/albert-api-client.ts
+++ b/server/utils/albert-api-client.ts
@@ -85,6 +85,13 @@ async function makeAlbertRequest(
     return response
   }
   catch (error) {
+    const errorDetails: Record<string, unknown> = {
+      method,
+      url,
+      ...(error && typeof error === 'object' ? error : {}),
+    }
+
+    console.error(`[Albert API] ${method} ${url} failed:`, JSON.stringify(errorDetails, null, 2))
     throw new Error(`API request failed: ${(error as Error).message}`)
   }
 }


### PR DESCRIPTION
The [Albert API outage on 2026/01/28](https://albert.status.etalab.gouv.fr/status/api) highlighted that our current error-handling logic is insufficient for quickly diagnosing issues when the API fails.

This PR adds error logging to Albert API client for better debugging. Logs method, URL, and full error details when API requests fail, making it easier to diagnose connection and response issues.