### PR TITLE
feat(2fa): move 2fa status in modal to prevent freshness issues

### DIFF
--- a/components/User/AdminUserProfilePage.vue
+++ b/components/User/AdminUserProfilePage.vue
@@ -222,27 +222,16 @@
         v-if="user.id === me.id"
         class="fr-input-group"
       >
-        <label class="fr-label mb-2">
-          {{ $t('Authentification deux facteurs') }}
-        </label>
-        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-          <div class="fr-col-12 fr-col-sm-7 fr-col-lg-8 fr-col-xl-9">
-            <div class="fr-input-wrap relative">
-              <input
-                :value="twoFactorStatus === 'authenticator' ? $t('Configuré') : $t('Non configuré')"
-                class="fr-input"
-                disabled
-                type="text"
-              >
-            </div>
-          </div>
-          <div class="fr-col-auto">
-            <TwoFactorSetupModal
-              :is-configured="twoFactorStatus === 'authenticator'"
-              @setup-complete="refreshTwoFactorStatus"
-            />
-          </div>
-        </div>
+        <BannerAction
+          type="warning"
+          :title="$t('Authentification deux facteurs')"
+          class="mt-4"
+        >
+          {{ $t("Configurer l'authentification deux facteurs") }}
+          <template #button>
+            <TwoFactorSetupModal />
+          </template>
+        </BannerAction>
       </div>
       <BannerAction
         type="danger"
@@ -292,9 +281,6 @@ const profilePicture = ref<File | null>(null)
 
 const { data: allRoles } = await useAPI<Array<{ name: string }>>('/api/1/users/roles')
 const allRolesAsString = computed(() => (allRoles.value || []).map(r => r.name))
-
-const { data: twoFactorData, refresh: refreshTwoFactorStatus } = await useAPI<{ response: { tf_primary_method: string } | null }>('/tf-setup')
-const twoFactorStatus = computed(() => twoFactorData.value?.response?.tf_primary_method ?? null)
 
 const { form } = useForm(props.user, {}, {})
 watchEffect(() => {


### PR DESCRIPTION
Indeed, a GET on /tf-setup requires freshness, redirecting to home if the session is older.
We don't need freshness for the rest of the profile page.

This PR only adds an error toast explaining the issue if freshness is not ok.
Freshness update logic is implemented in [a distinct PR](https://github.com/datagouv/cdata/pull/920) that requires udata update as well.