### PR TITLE
feat: use search endpoint in admin table

### DIFF
--- a/components/Dataservices/AdminDataservicesPage.vue
+++ b/components/Dataservices/AdminDataservicesPage.vue
@@ -126,14 +126,15 @@ function sort(column: DataserviceSortedBy, newDirection: SortDirection) {
   direction.value = newDirection
 }
 
-const apiUrl = computed(() => qDebounced.value ? '/api/2/dataservices/search/' : '/api/1/dataservices/')
+const useSearchEndpoint = computed(() => !!qDebounced.value)
+const apiUrl = computed(() => useSearchEndpoint.value ? '/api/2/dataservices/search/' : '/api/1/dataservices/')
 
 const params = computed(() => {
   return {
     organization: props.organization?.id,
     owner: props.user?.id,
 
-    sort: sortDirection.value,
+    sort: useSearchEndpoint.value ? undefined : sortDirection.value,
     q: qDebounced.value,
     page_size: pageSize.value,
     page: page.value,

--- a/components/Datasets/AdminDatasetsPage.vue
+++ b/components/Datasets/AdminDatasetsPage.vue
@@ -170,13 +170,14 @@ function resetFilters() {
   datasetsStatus.value = null
 }
 
-const apiUrl = computed(() => qDebounced.value && !datasetsStatus.value ? '/api/2/datasets/search/' : '/api/2/datasets/')
+const useSearchEndpoint = computed(() => !!qDebounced.value && !datasetsStatus.value)
+const apiUrl = computed(() => useSearchEndpoint.value ? '/api/2/datasets/search/' : '/api/2/datasets/')
 
 const params = computed(() => {
   const query: {
     organization: string | undefined
     owner: string | undefined
-    sort: string
+    sort: string | undefined
     q: string
     page_size: number
     page: number
@@ -187,7 +188,7 @@ const params = computed(() => {
     organization: props.organization?.id,
     owner: props.user?.id,
 
-    sort: sortDirection.value,
+    sort: useSearchEndpoint.value ? undefined : sortDirection.value,
     q: qDebounced.value,
     page_size: pageSize.value,
     page: page.value,

--- a/components/Reuses/AdminReusesPage.vue
+++ b/components/Reuses/AdminReusesPage.vue
@@ -118,14 +118,15 @@ function sort(column: ReuseSortedBy, newDirection: SortDirection) {
   direction.value = newDirection
 }
 
-const apiUrl = computed(() => qDebounced.value ? '/api/2/reuses/search/' : '/api/1/reuses/')
+const useSearchEndpoint = computed(() => !!qDebounced.value)
+const apiUrl = computed(() => useSearchEndpoint.value ? '/api/2/reuses/search/' : '/api/1/reuses/')
 
 const params = computed(() => {
   return {
     organization: props.organization?.id,
     owner: props.user?.id,
 
-    sort: sortDirection.value,
+    sort: useSearchEndpoint.value ? undefined : sortDirection.value,
     q: qDebounced.value,
     page_size: pageSize.value,
     page: page.value,

--- a/pages/admin/site/organizations.vue
+++ b/pages/admin/site/organizations.vue
@@ -191,18 +191,16 @@ const sortDirection = computed(() => `${direction.value === 'asc' ? '' : '-'}${s
 const q = ref('')
 const qDebounced = refDebounced(q, config.public.searchDebounce)
 
-const url = computed(() => {
-  const baseEndpoint = qDebounced.value ? '/api/2/organizations/search/' : '/api/1/organizations'
-  const url = new URL(baseEndpoint, config.public.apiBase)
+const useSearchEndpoint = computed(() => !!qDebounced.value)
+const apiUrl = computed(() => useSearchEndpoint.value ? '/api/2/organizations/search/' : '/api/1/organizations/')
 
-  url.searchParams.set('deleted', 'true')
-  url.searchParams.set('sort', sortDirection.value)
-  url.searchParams.set('q', qDebounced.value)
-  url.searchParams.set('page_size', pageSize.value.toString())
-  url.searchParams.set('page', page.value.toString())
+const params = computed(() => ({
+  deleted: 'true',
+  sort: useSearchEndpoint.value ? undefined : sortDirection.value,
+  q: qDebounced.value,
+  page_size: pageSize.value,
+  page: page.value,
+}))
 
-  return url.toString()
-})
-
-const { data: pageData, status } = await useAPI<PaginatedArray<Organization>>(url, { lazy: true })
+const { data: pageData, status } = await useAPI<PaginatedArray<Organization>>(apiUrl, { lazy: true, query: params })
 </script>


### PR DESCRIPTION
- [x] use /search endpoints when `q` is defined
- [x] since the /api/2/datasets/search endpoint doesn't support some filters, disable it
- [x] refactor org listing to use `useAPI` direct `query` params instead of building the URL