### PR TITLE
feat: remove base API from URLs

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -2,13 +2,16 @@ import type { FieldsErrors } from '~/types/form'
 
 export function useAbsoluteUrlToRelative() {
   const currentUrl = useRequestURL()
+  const config = useRuntimeConfig()
+  // Normalize without trailing slash so url.slice(apiBase.length) always gives a path starting with "/"
+  const apiBase = (config.public.apiBase as string | undefined)?.replace(/\/$/, '')
 
   return (url: string): string => {
     try {
       const baseUrl = `${currentUrl.protocol}//${currentUrl.host}`
 
-      if (!url.startsWith(baseUrl)) return url
-      return url.slice(baseUrl.length)
+      if (url.startsWith(baseUrl)) return url.slice(baseUrl.length)
+      if (apiBase && url.startsWith(apiBase)) return url.slice(apiBase.length) || '/'
     }
     catch {
       // This is not an absolute URL, return the raw one


### PR DESCRIPTION
When configuring `NUXT_PUBLIC_API_BASE=https://demo.data.gouv.fr` the links returned by the API will redirect to the real demo env. This change allows to stay on localhost:3000.