### PR TITLE
fix: elections pages are slow to load

### DIFF
--- a/pages/posts/[id].vue
+++ b/pages/posts/[id].vue
@@ -106,8 +106,7 @@ const route = useRoute()
 const { formatDate } = useFormatDate()
 
 const url = computed(() => `/api/1/posts/${route.params.id}/`)
-// lazy on client only: preserves SSR data fetching (SEO) while making client-side navigation instant
-const { data: post, status } = await useAPI<Post>(url, { redirectOn404: true, lazy: import.meta.client })
+const { data: post, status } = await useAPI<Post>(url, { redirectOn404: true, lazy: true })
 
 const name = computed(() => post.value?.name)
 const robots = computed(() => !post.value?.published ? 'noindex, nofollow' : 'all')


### PR DESCRIPTION
Nuxt's useFetch options lazy and server are orthogonal: lazy controls whether the fetch blocks rendering/navigation, while server controls whether the fetch runs on the server at all. There is no combination of these options that achieves "block during SSR but don't block during client-side navigation" (https://github.com/nuxt/nuxt/issues/19326). Setting lazy: true makes navigation instant but also skips server-side data fetching, which hurts SEO. Setting server: true, lazy: false (the default) preserves SSR but blocks client-side navigation until the API responds. Using lazy: import.meta.client leverages Vite's compile-time constants to get the best of both worlds: the server bundle gets lazy: false (data is fetched during SSR), while the client bundle gets lazy: true (instant navigation with a loading state).