### PR TITLE
fix: typo in date sentence

### DIFF
--- a/datagouv-components/src/components/ResourceExplorer/ResourceExplorerViewer.vue
+++ b/datagouv-components/src/components/ResourceExplorer/ResourceExplorerViewer.vue
@@ -17,7 +17,7 @@
           />
         </div>
         <div class="text-gray-medium text-xs flex items-center gap-1">
-          <span>{{ t('mis à jour le {date}', { date: formatRelativeIfRecentDate(resource.last_modified) }) }}</span>
+          <span>{{ t('mis à jour {date}', { date: formatRelativeIfRecentDate(resource.last_modified) }) }}</span>
           <RiSubtractLine
             aria-hidden="true"
             class="size-3 fill-gray-medium"


### PR DESCRIPTION
<img width="580" height="112" alt="image" src="https://github.com/user-attachments/assets/c5e68de5-16c3-4238-a620-7ab31c862aea" />
