### PR TITLE
chore: bump @datagouv/components-next to v1.0.0

### DIFF
--- a/datagouv-components/package.json
+++ b/datagouv-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datagouv/components-next",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "private": false,
   "type": "module",
   "packageManager": "pnpm@10.23.0",


### PR DESCRIPTION
Bump `@datagouv/components-next` to v1.0.0.