### PR TITLE
feat: show restricted category definition

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -124,7 +124,7 @@ export default defineNuxtConfig({
 
       datasetPublishingGuideUrl: 'https://guides.data.gouv.fr/publier-des-donnees/guide-qualite/ameliorer-la-qualite-dun-jeu-de-donnees-en-continu/ameliorer-le-score-de-qualite-des-metadonnees',
       datasetQualityGuideUrl: 'https://guides.data.gouv.fr/guides-open-data/guide-qualite/ameliorer-la-qualite-dun-jeu-de-donnees-en-continu/ameliorer-le-score-de-qualite-des-metadonnees',
-      datasetRestrictedGuideUrl: 'https://guides.data.gouv.fr/guides-open-data/guide-juridique/producteurs-de-donnees/quelles-sont-les-obligations',
+      datasetRestrictedGuideUrl: 'https://guides.data.gouv.fr/guides/guide-juridique/producteurs-de-donnees/quelles-sont-les-obligations',
       dataSearchFeedbackFormUrl: 'https://tally.so/r/mDKv1N',
       forumUrl: 'https://forum.data.gouv.fr/',
       generateShortDescriptionFeedbackUrl: 'https://tally.so/r/wbbRxo',

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -651,7 +651,7 @@ const datasetDownloadsResources = computed(() => datasetMetrics.value?.downloads
 const datasetVisitsTotal = computed(() => datasetMetrics.value?.visitsTotal ?? 0)
 const datasetDownloadsResourcesTotal = computed(() => datasetMetrics.value?.downloadsTotal ?? 0)
 
-const { data: categories } = await useAPI<Array<{ value: string, label: string }>>('/api/1/access_type/reason_categories')
+const { data: categories } = await useAPI<Array<{ value: string, label: string, definition: string }>>('/api/1/access_type/reason_categories')
 const category = computed(() => {
   if (!dataset.value?.access_type_reason_category) return null
   return categories.value?.find(c => c.value === dataset.value?.access_type_reason_category)

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -392,12 +392,14 @@
               >
                 {{ dataset.access_type_reason }}
               </p>
-              <p
-                v-else-if="category"
-                class="text-sm"
-              >
-                {{ category.label }}
-              </p>
+              <template v-else-if="category">
+                <p class="font-bold text-sm mb-1">
+                  {{ category.label }}
+                </p>
+                <p class="text-sm">
+                  {{ category.definition }}
+                </p>
+              </template>
               <p
                 v-if="config.public.datasetRestrictedGuideUrl"
                 class="mb-0"


### PR DESCRIPTION
It adds more information than the simple label category.

Before
<img width="1216" height="174" alt="image" src="https://github.com/user-attachments/assets/6388199d-18f5-4eb7-932e-f7f55a8ac3e7" />

After
<img width="1216" height="198" alt="image" src="https://github.com/user-attachments/assets/8d83e879-e734-4a26-b612-301040ff4a79" />

Also fix the restricted guide URL (I've added a redirect also in the guides directly).