### PR TITLE
fix: better wording for schema-related dataset

### DIFF
--- a/composables/useRecommendationReason.ts
+++ b/composables/useRecommendationReason.ts
@@ -8,7 +8,7 @@ export function useRecommendationReason() {
       case 'edito':
         return t(`par l'équipe de {site}`, { site: config.public.title })
       case 'schemas':
-        return t('car conforme au schéma de données | car conformes aux schémas de données', { count })
+        return t('car lié au schéma de données | car liés aux schémas de données', { count })
       default:
         return t('')
     }


### PR DESCRIPTION
Currently not accurate if a resource is invalid ([example](https://www.data.gouv.fr/datasets/depenses-agec-2024-1))