### PR TITLE
fix: oembeds link

### DIFF
--- a/layouts/embed.vue
+++ b/layouts/embed.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+const router = useRouter()
+router.beforeEach((to) => {
+  if (!to.path.includes('/embeds/')) {
+    window.top!.location.href = to.fullPath
+    return false
+  }
+})
+</script>
+
+<template>
+  <div>
+    <slot />
+  </div>
+</template>

--- a/pages/embeds/dataservices/[slug].vue
+++ b/pages/embeds/dataservices/[slug].vue
@@ -4,6 +4,6 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: false,
+  layout: 'embed',
 })
 </script>

--- a/pages/embeds/datasets/[slug].vue
+++ b/pages/embeds/datasets/[slug].vue
@@ -4,6 +4,6 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: false,
+  layout: 'embed',
 })
 </script>

--- a/pages/embeds/list-reuses/[slug].vue
+++ b/pages/embeds/list-reuses/[slug].vue
@@ -6,6 +6,6 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: false,
+  layout: 'embed',
 })
 </script>

--- a/pages/embeds/organizations/[slug].vue
+++ b/pages/embeds/organizations/[slug].vue
@@ -4,6 +4,6 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: false,
+  layout: 'embed',
 })
 </script>

--- a/pages/embeds/reuses/[slug].vue
+++ b/pages/embeds/reuses/[slug].vue
@@ -4,6 +4,6 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: false,
+  layout: 'embed',
 })
 </script>

--- a/pages/embeds/search-dataservices/[slug].vue
+++ b/pages/embeds/search-dataservices/[slug].vue
@@ -6,6 +6,6 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: false,
+  layout: 'embed',
 })
 </script>

--- a/pages/embeds/search-datasets/[slug].vue
+++ b/pages/embeds/search-datasets/[slug].vue
@@ -6,6 +6,6 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: false,
+  layout: 'embed',
 })
 </script>


### PR DESCRIPTION
When we click on an oembed card, the link is loaded inside the iframe instead of propagating to the parent.