### PR TITLE
chore: enable pull_request run for external contributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
With this line we should have a "Approve and run" button on external contributions to run the CI.