### PR TITLE
fix: cell overflow in moderation dashboard

### DIFF
--- a/pages/admin/site/moderation.vue
+++ b/pages/admin/site/moderation.vue
@@ -94,7 +94,7 @@
               v-for="report in pageData.data"
               :key="report.id"
             >
-              <td>
+              <td class="overflow-hidden">
                 <template v-if="subjects[report.id]">
                   <div v-if="subjects[report.id].value">
                     <LinkToSubject


### PR DESCRIPTION
Not the best solution but it's really weird and truncation in CSS is hard to understand…