### PR TITLE
fix: mobileVisibleFields signature

### DIFF
--- a/datagouv-components/src/components/TabularExplorer/TabularExplorer.vue
+++ b/datagouv-components/src/components/TabularExplorer/TabularExplorer.vue
@@ -292,7 +292,7 @@
           :class="i % 2 === 1 ? 'bg-gray-lowest-2' : 'bg-white'"
         >
           <div
-            v-for="col in mobileVisibleFields(row, i)"
+            v-for="col in mobileVisibleFields(i)"
             :key="col"
             class="flex flex-col gap-0.5 min-w-0"
           >
@@ -751,7 +751,7 @@ const mobileFilterOpen = ref(false)
 const mobileExpandedRows = ref(new Set<number>())
 const mobileFilterExpandedCol = ref<string | null>(null)
 
-function mobileVisibleFields(row: TabularRow, index: number): string[] {
+function mobileVisibleFields(index: number): string[] {
   if (displayedColumns.value.length <= 4 || mobileExpandedRows.value.has(index)) {
     return displayedColumns.value
   }


### PR DESCRIPTION
The error leaks in downstream projects with stricter typechecking settings:

```
❯ pnpm run type-check

> udata-front-kit@0.4.0 type-check /Users/alexandre/Developer/Ecolab/Ecopshères/ecospheres-front
> vue-tsc --noEmit --project tsconfig.app.json

node_modules/@datagouv/components-next/src/components/TabularExplorer/TabularExplorer.vue:754:30 - error TS6133: 'row' is declared but its value is never read.

754 function mobileVisibleFields(row: TabularRow, index: number): string[] {
                                 ~~~


Found 1 error in node_modules/@datagouv/components-next/src/components/TabularExplorer/TabularExplorer.vue:754

 ELIFECYCLE  Command failed with exit code 1.
```