### PR TITLE
fix(search): clear custom filters

### DIFF
--- a/datagouv-components/src/composables/useSearchFilter.ts
+++ b/datagouv-components/src/composables/useSearchFilter.ts
@@ -1,4 +1,5 @@
 import { type InjectionKey, type Ref, inject, onMounted, onScopeDispose } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useRouteQuery } from '@vueuse/router'
 
 export interface CustomFilterEntry {
@@ -69,6 +70,8 @@ export function useSearchFilter(
 
   const { apiParam = urlParam, defaultValue = undefined } = options
 
+  const route = useRoute()
+  const router = useRouter()
   const value = useRouteQuery<string | undefined>(urlParam, defaultValue)
 
   // Register in onMounted to avoid SSR/hydration mismatch: the registry must be
@@ -82,7 +85,19 @@ export function useSearchFilter(
     // own `watch(currentType)` logic that drops built-in filters which don't
     // apply to the new type: a custom filter's applicability is signalled
     // by the consumer via `v-if`, so its unmount is the equivalent signal.
-    value.value = defaultValue
+    //
+    // We cannot use `value.value = defaultValue` here because VueUse's
+    // useRouteQuery registers its own tryOnScopeDispose cleanup that zeroes
+    // the internal `query` variable to undefined (FIFO order, it runs first).
+    // The setter then sees `query === v` and early-returns without ever
+    // calling router.replace(). Instead we read the live route.query directly
+    // (which is router state, not affected by that cleanup) and push the update.
+    if (route.query[urlParam] !== undefined) {
+      const { [urlParam]: _removed, ...restQuery } = route.query
+      router.replace({
+        query: defaultValue === undefined ? restQuery : { ...restQuery, [urlParam]: String(defaultValue) },
+      })
+    }
     context.unregister(urlParam)
   })
 

--- a/tests/datasets/search.spec.ts
+++ b/tests/datasets/search.spec.ts
@@ -159,6 +159,33 @@ test('custom theme filter is hidden on non-dataset types', async ({ page }) => {
   await expect(page.locator('#theme-filter')).not.toBeVisible()
 })
 
+test('custom theme filter URL param is cleared when switching to a type that hides it', async ({ page }) => {
+  await page.goto('/design/dataset-search?theme=transport')
+
+  await expect(page.locator('#theme-filter')).toHaveValue('transport')
+
+  const reusesRadio = page.getByRole('radio', { name: 'Réutilisations' })
+  await reusesRadio.click({ force: true })
+
+  await page.waitForURL(url => !url.searchParams.has('theme'))
+  const url = new URL(page.url())
+  expect(url.searchParams.has('theme')).toBeFalsy()
+})
+
+test('custom theme filter URL param persists when switching between types that both show it', async ({ page }) => {
+  await page.goto('/design/dataset-search?theme=transport')
+
+  await expect(page.locator('#theme-filter')).toHaveValue('transport')
+
+  const inspireRadio = page.getByRole('radio', { name: 'Données INSPIRE' })
+  await inspireRadio.click({ force: true })
+
+  await page.waitForLoadState('networkidle')
+  const url = new URL(page.url())
+  expect(url.searchParams.get('theme')).toBe('transport')
+  await expect(page.locator('#theme-filter')).toHaveValue('transport')
+})
+
 test('custom theme filter resets page to 1 on change', async ({ page }) => {
   await page.goto('/design/dataset-search?page=2')
 


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1088

Fixes a nifty bug that prevented custom filters to be cleared when switching types, using a v-if structure on type in downstream.