### PR TITLE
feat(search): type aware custom filters

### DIFF
--- a/components/Design/ThemeTagFilter.vue
+++ b/components/Design/ThemeTagFilter.vue
@@ -37,5 +37,5 @@ const themes = [
 ]
 
 // ?theme=environnement in URL → tag=environnement in API
-const value = useSearchFilter('theme', { apiParam: 'tag' })
+const value = useSearchFilter('theme', { apiParam: 'tag', typeKeys: ['all-datasets', 'inspire-datasets'] })
 </script>

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -356,7 +356,7 @@ import { RiBookShelfLine, RiBuilding2Line, RiCloseCircleLine, RiDatabase2Line, R
 import magnifyingGlassSrc from '../../../assets/illustrations/magnifying_glass.svg?url'
 import { useTranslation } from '../../composables/useTranslation'
 import { useDebouncedRef } from '../../composables/useDebouncedRef'
-import { forEachActiveCustomFilter, isCustomFilterActive, searchFilterContextKey, type CustomFilterEntry } from '../../composables/useSearchFilter'
+import { configKey, forEachActiveCustomFilter, isCustomFilterActive, searchFilterContextKey, type CustomFilterEntry } from '../../composables/useSearchFilter'
 import { useStableQueryParams } from '../../composables/useStableQueryParams'
 import { useComponentsConfig } from '../../config'
 import { useFetch } from '../../functions/api'
@@ -366,7 +366,7 @@ import type { Dataservice } from '../../types/dataservices'
 import type { Organization } from '../../types/organizations'
 import type { Reuse } from '../../types/reuses'
 import type { TopicV2 } from '../../types/topics'
-import type { GlobalSearchConfig, SearchResponseByClass, SearchType, SearchTypeConfig, SortOption, FacetItem } from '../../types/search'
+import type { GlobalSearchConfig, SearchResponseByClass, SearchType, SortOption, FacetItem } from '../../types/search'
 import { getDefaultGlobalSearchConfig } from '../../types/search'
 import BrandedButton from '../BrandedButton.vue'
 import LoadingBlock from '../LoadingBlock.vue'
@@ -405,8 +405,6 @@ const props = withDefaults(defineProps<{
   config: getDefaultGlobalSearchConfig,
   hideSearchInput: false,
 })
-
-const configKey = (c: SearchTypeConfig) => c.key ?? c.class
 
 // defineModel's default is static and can't depend on props, so we cast and initialize manually
 const currentType = defineModel<string>('type') as Ref<string>
@@ -742,7 +740,7 @@ const rssUrl = computed(() => {
 
   forEachActiveCustomFilter(customFilterRegistry, (apiParam, value) => {
     params.set(apiParam, value)
-  }, currentTypeConfig.value?.key ?? currentTypeConfig.value?.class)
+  }, currentTypeConfig.value ? configKey(currentTypeConfig.value) : undefined)
 
   // Add sort if set
   if (sort.value) params.set('sort', sort.value)

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -742,7 +742,7 @@ const rssUrl = computed(() => {
 
   forEachActiveCustomFilter(customFilterRegistry, (apiParam, value) => {
     params.set(apiParam, value)
-  })
+  }, currentTypeConfig.value?.key ?? currentTypeConfig.value?.class)
 
   // Add sort if set
   if (sort.value) params.set('sort', sort.value)

--- a/datagouv-components/src/composables/useSearchFilter.ts
+++ b/datagouv-components/src/composables/useSearchFilter.ts
@@ -6,6 +6,7 @@ export interface CustomFilterEntry {
   apiParam: string
   ref: Ref<string | undefined>
   defaultValue: string | undefined
+  typeKeys?: string[] // undefined = applies to all types
 }
 
 export interface SearchFilterContext {
@@ -21,9 +22,11 @@ export function isCustomFilterActive(entry: CustomFilterEntry): boolean {
 export function forEachActiveCustomFilter(
   registry: Map<string, CustomFilterEntry>,
   apply: (apiParam: string, value: string) => void,
+  typeKey?: string,
 ): void {
   for (const entry of registry.values()) {
     if (!isCustomFilterActive(entry)) continue
+    if (typeKey && entry.typeKeys && !entry.typeKeys.includes(typeKey)) continue
     apply(entry.apiParam, String(entry.ref.value))
   }
 }
@@ -36,6 +39,8 @@ export interface UseSearchFilterOptions {
   apiParam?: string
   /** Default value when not present in URL. Defaults to undefined. */
   defaultValue?: string
+  /** One or more type config keys this filter applies to. Undefined means all types. */
+  typeKeys?: string | string[]
 }
 
 /**
@@ -68,7 +73,10 @@ export function useSearchFilter(
     )
   }
 
-  const { apiParam = urlParam, defaultValue = undefined } = options
+  const { apiParam = urlParam, defaultValue = undefined, typeKeys } = options
+  const normalizedTypeKeys = typeKeys
+    ? (Array.isArray(typeKeys) ? typeKeys : [typeKeys])
+    : undefined
 
   const route = useRoute()
   const router = useRouter()
@@ -77,7 +85,7 @@ export function useSearchFilter(
   // Register in onMounted to avoid SSR/hydration mismatch: the registry must be
   // empty during SSR so server and client produce the same initial HTML.
   onMounted(() => {
-    context.register(urlParam, { apiParam, ref: value, defaultValue })
+    context.register(urlParam, { apiParam, ref: value, defaultValue, typeKeys: normalizedTypeKeys })
   })
 
   onScopeDispose(() => {

--- a/datagouv-components/src/composables/useSearchFilter.ts
+++ b/datagouv-components/src/composables/useSearchFilter.ts
@@ -1,6 +1,11 @@
 import { type InjectionKey, type Ref, inject, onMounted, onScopeDispose } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useRouteQuery } from '@vueuse/router'
+import type { SearchTypeConfig } from '../types/search'
+
+export function configKey(c: SearchTypeConfig): string {
+  return c.key ?? c.class
+}
 
 export interface CustomFilterEntry {
   apiParam: string

--- a/datagouv-components/src/composables/useStableQueryParams.ts
+++ b/datagouv-components/src/composables/useStableQueryParams.ts
@@ -1,6 +1,6 @@
 import { computed, ref, watch, type Ref } from 'vue'
 import type { SearchTypeConfig } from '../types/search'
-import { forEachActiveCustomFilter, type CustomFilterEntry } from './useSearchFilter'
+import { configKey, forEachActiveCustomFilter, type CustomFilterEntry } from './useSearchFilter'
 
 type FilterRefs = Record<string, Ref<unknown>>
 
@@ -57,7 +57,7 @@ export function useStableQueryParams(options: StableQueryParamsOptions) {
     // combines with an existing built-in value instead of overwriting it.
     // Pass the current type key so filters scoped to specific types are excluded
     // from background fetches for other types.
-    const currentTypeKey = typeConfig?.key ?? typeConfig?.class
+    const currentTypeKey = typeConfig ? configKey(typeConfig) : undefined
     forEachActiveCustomFilter(customFilterRegistry, (apiParam, value) => {
       const existing = params[apiParam]
       if (existing === undefined) {

--- a/datagouv-components/src/composables/useStableQueryParams.ts
+++ b/datagouv-components/src/composables/useStableQueryParams.ts
@@ -55,6 +55,9 @@ export function useStableQueryParams(options: StableQueryParamsOptions) {
     // 3.5. Apply custom filter values. Concatenate into an array on collision
     // so a custom filter mapped onto a built-in apiParam (e.g. theme → tag)
     // combines with an existing built-in value instead of overwriting it.
+    // Pass the current type key so filters scoped to specific types are excluded
+    // from background fetches for other types.
+    const currentTypeKey = typeConfig?.key ?? typeConfig?.class
     forEachActiveCustomFilter(customFilterRegistry, (apiParam, value) => {
       const existing = params[apiParam]
       if (existing === undefined) {
@@ -63,7 +66,7 @@ export function useStableQueryParams(options: StableQueryParamsOptions) {
       else {
         params[apiParam] = Array.isArray(existing) ? [...existing, value] : [existing, value]
       }
-    })
+    }, currentTypeKey)
 
     // 4. Always include q, sort (if valid for this type), page, page_size
     if (q.value) {

--- a/tests/datasets/search.spec.ts
+++ b/tests/datasets/search.spec.ts
@@ -234,6 +234,48 @@ test('custom theme filter applies its apiParam mapping to the results', async ({
   ).toBeVisible()
 })
 
+test('type-scoped custom filter change does not trigger a re-fetch for non-matching types', async ({ page }) => {
+  await page.goto('/design/dataset-search')
+  await page.waitForLoadState('networkidle')
+
+  // Track new dataservices requests after initial load settles
+  let dataservicesRefired = false
+  page.on('request', (req) => {
+    if (req.url().includes('/api/2/dataservices/search/')) dataservicesRefired = true
+  })
+
+  // Wait for datasets to re-fetch with the new filter (confirms the change was processed)
+  const datasetsRefiredPromise = page.waitForRequest(
+    req =>
+      req.url().includes('/api/2/datasets/search/')
+      && new URL(req.url()).searchParams.get('tag') === 'transport',
+  )
+
+  const themeSelect = page.locator('#theme-filter')
+  await themeSelect.scrollIntoViewIfNeeded()
+  await themeSelect.selectOption('transport')
+  await datasetsRefiredPromise
+
+  // dataservices params are unaffected by the theme filter, so no re-fetch
+  expect(dataservicesRefired).toBe(false)
+})
+
+test('type-scoped custom filter applies to other matching types in background searches', async ({ page }) => {
+  // inspire-datasets (badge=inspire) is also in typeKeys, so its background search
+  // must include tag=transport even though it is not the initial active type.
+  const inspireReqPromise = page.waitForRequest(
+    req =>
+      req.url().includes('/api/2/datasets/search/')
+      && new URL(req.url()).searchParams.get('badge') === 'inspire',
+  )
+
+  await page.goto('/design/dataset-search?theme=transport')
+
+  const inspireReq = await inspireReqPromise
+  const url = new URL(inspireReq.url())
+  expect(url.searchParams.get('tag')).toBe('transport')
+})
+
 test('clicking dataset navigates to detail', async ({ page }) => {
   await page.goto('/datasets/search/')
   // Wait for Vue hydration before clicking NuxtLink (fix flaky test on Firefox)

--- a/tests/datasets/search.spec.ts
+++ b/tests/datasets/search.spec.ts
@@ -234,7 +234,7 @@ test('custom theme filter applies its apiParam mapping to the results', async ({
   ).toBeVisible()
 })
 
-test('type-scoped custom filter does not appear in non-matching type requests', async ({ page }) => {
+test('custom filter scoped to dataset types never appears in the parallel dataservices search', async ({ page }) => {
   // Collect tag values from every dataservices request (initial + any re-fetches)
   const dataservicesTags: (string | null)[] = []
   page.on('request', (req) => {
@@ -246,7 +246,8 @@ test('type-scoped custom filter does not appear in non-matching type requests', 
   await page.goto('/design/dataset-search')
   await page.waitForLoadState('networkidle')
 
-  // Change the filter and wait for datasets (non-INSPIRE tab) to re-fetch with tag=transport
+  // Change the theme filter and wait for the all-datasets search to re-fetch with tag=transport
+  // (confirms the filter change was processed before we check dataservices)
   const datasetsWithTagPromise = page.waitForRequest(
     req =>
       req.url().includes('/api/2/datasets/search/')
@@ -259,29 +260,8 @@ test('type-scoped custom filter does not appear in non-matching type requests', 
   await themeSelect.selectOption('transport')
   await datasetsWithTagPromise
 
-  // tag=transport must never appear in any dataservices request
+  // tag=transport must never have appeared in any dataservices request
   expect(dataservicesTags.every(tag => tag !== 'transport')).toBe(true)
-})
-
-test('type-scoped custom filter applies to other matching types on filter change', async ({ page }) => {
-  await page.goto('/design/dataset-search')
-  await page.waitForLoadState('networkidle')
-
-  // Wait for inspire-datasets to re-fetch with tag=transport after the filter is applied.
-  // We wait for page load first so ThemeTagFilter is already registered before we change
-  // the value — avoiding the race where the first lazy fetch fires before onMounted.
-  const inspireWithTagPromise = page.waitForRequest(
-    req =>
-      req.url().includes('/api/2/datasets/search/')
-      && new URL(req.url()).searchParams.get('badge') === 'inspire'
-      && new URL(req.url()).searchParams.get('tag') === 'transport',
-  )
-
-  const themeSelect = page.locator('#theme-filter')
-  await themeSelect.scrollIntoViewIfNeeded()
-  await themeSelect.selectOption('transport')
-
-  await inspireWithTagPromise
 })
 
 test('clicking dataset navigates to detail', async ({ page }) => {

--- a/tests/datasets/search.spec.ts
+++ b/tests/datasets/search.spec.ts
@@ -234,46 +234,54 @@ test('custom theme filter applies its apiParam mapping to the results', async ({
   ).toBeVisible()
 })
 
-test('type-scoped custom filter change does not trigger a re-fetch for non-matching types', async ({ page }) => {
+test('type-scoped custom filter does not appear in non-matching type requests', async ({ page }) => {
+  // Collect tag values from every dataservices request (initial + any re-fetches)
+  const dataservicesTags: (string | null)[] = []
+  page.on('request', (req) => {
+    if (req.url().includes('/api/2/dataservices/search/')) {
+      dataservicesTags.push(new URL(req.url()).searchParams.get('tag'))
+    }
+  })
+
   await page.goto('/design/dataset-search')
   await page.waitForLoadState('networkidle')
 
-  // Track new dataservices requests after initial load settles
-  let dataservicesRefired = false
-  page.on('request', (req) => {
-    if (req.url().includes('/api/2/dataservices/search/')) dataservicesRefired = true
-  })
-
-  // Wait for datasets to re-fetch with the new filter (confirms the change was processed)
-  const datasetsRefiredPromise = page.waitForRequest(
+  // Change the filter and wait for datasets (non-INSPIRE tab) to re-fetch with tag=transport
+  const datasetsWithTagPromise = page.waitForRequest(
     req =>
       req.url().includes('/api/2/datasets/search/')
+      && new URL(req.url()).searchParams.get('tag') === 'transport'
+      && !new URL(req.url()).searchParams.has('badge'),
+  )
+
+  const themeSelect = page.locator('#theme-filter')
+  await themeSelect.scrollIntoViewIfNeeded()
+  await themeSelect.selectOption('transport')
+  await datasetsWithTagPromise
+
+  // tag=transport must never appear in any dataservices request
+  expect(dataservicesTags.every(tag => tag !== 'transport')).toBe(true)
+})
+
+test('type-scoped custom filter applies to other matching types on filter change', async ({ page }) => {
+  await page.goto('/design/dataset-search')
+  await page.waitForLoadState('networkidle')
+
+  // Wait for inspire-datasets to re-fetch with tag=transport after the filter is applied.
+  // We wait for page load first so ThemeTagFilter is already registered before we change
+  // the value — avoiding the race where the first lazy fetch fires before onMounted.
+  const inspireWithTagPromise = page.waitForRequest(
+    req =>
+      req.url().includes('/api/2/datasets/search/')
+      && new URL(req.url()).searchParams.get('badge') === 'inspire'
       && new URL(req.url()).searchParams.get('tag') === 'transport',
   )
 
   const themeSelect = page.locator('#theme-filter')
   await themeSelect.scrollIntoViewIfNeeded()
   await themeSelect.selectOption('transport')
-  await datasetsRefiredPromise
 
-  // dataservices params are unaffected by the theme filter, so no re-fetch
-  expect(dataservicesRefired).toBe(false)
-})
-
-test('type-scoped custom filter applies to other matching types in background searches', async ({ page }) => {
-  // inspire-datasets (badge=inspire) is also in typeKeys, so its background search
-  // must include tag=transport even though it is not the initial active type.
-  const inspireReqPromise = page.waitForRequest(
-    req =>
-      req.url().includes('/api/2/datasets/search/')
-      && new URL(req.url()).searchParams.get('badge') === 'inspire',
-  )
-
-  await page.goto('/design/dataset-search?theme=transport')
-
-  const inspireReq = await inspireReqPromise
-  const url = new URL(inspireReq.url())
-  expect(url.searchParams.get('tag')).toBe('transport')
+  await inspireWithTagPromise
 })
 
 test('clicking dataset navigates to detail', async ({ page }) => {


### PR DESCRIPTION
Fix https://github.com/ecolabdata/ecospheres/issues/1089

This introduces a new config parameter `typeKeys` that lets downstream say if a custom filter is shared across types or not. If it's not shared, the background search for other types is skipped. This behaves similarly to native filters.