### PR TITLE
chore: ignore local pnpm store directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 
 # Node dependencies
 node_modules
+.pnpm-store
 
 # Logs
 logs


### PR DESCRIPTION
Some setups use a project-local pnpm store (`.pnpm-store`) via `store-dir`. Ignoring it avoids accidental commits of cache artifacts and keeps the repo focused on source.