### PR TITLE
fix: empty search flash after search reset

### DIFF
--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -475,6 +475,11 @@ const showSidebar = computed(() => props.config.length > 1 || activeFilters.valu
 // URL query params
 const q = useRouteQuery<string>('q', '')
 const { debounced: qDebounced, flush: flushQ } = useDebouncedRef(q, componentsConfig.searchDebounce ?? 300)
+// When the search input is hidden, the parent owns the input and is expected
+// to debounce user typing itself (otherwise typing would land in the URL
+// instantly via v-model and stack two debounces). Bypass the internal debounce
+// so URL-driven q changes hit the fetch params immediately.
+const qForParams = computed(() => props.hideSearchInput ? q.value : qDebounced.value)
 const page = useRouteQuery('page', 1, { transform: Number })
 const sort = useRouteQuery<string | undefined>('sort')
 
@@ -550,7 +555,7 @@ watch(currentType, () => {
 const stableParamsOptions = {
   allFilters,
   customFilterRegistry,
-  q: qDebounced,
+  q: qForParams,
   sort,
   page,
   pageSize,
@@ -643,7 +648,7 @@ for (const c of props.config) {
 // intentionally excluded here to avoid resetting the page when a filter
 // registers with its URL-derived value.
 const filtersForReset = computed(() => ({
-  q: qDebounced.value,
+  q: qForParams.value,
   organization: organizationId.value,
   organization_badge: organizationType.value,
   tag: tag.value,
@@ -726,7 +731,7 @@ const rssUrl = computed(() => {
   }
 
   // Add active filters
-  if (qDebounced.value) params.set('q', qDebounced.value)
+  if (qForParams.value) params.set('q', qForParams.value)
   if (organizationId.value) params.set('organization', organizationId.value)
   if (organizationType.value) params.set('organization_badge', organizationType.value)
   if (tag.value) params.set('tag', tag.value)

--- a/pages/organizations/[oid].vue
+++ b/pages/organizations/[oid].vue
@@ -127,7 +127,7 @@
 <script setup lang="ts">
 import { isOrganizationCertified, LoadingBlock, MarkdownViewer, OrganizationNameWithCertificate, OwnerType, ReadMore, getOrganizationType, type Organization, OrganizationLogo } from '@datagouv/components-next'
 import { RiDeleteBinLine, RiSearchLine } from '@remixicon/vue'
-import { watchDebounced } from '@vueuse/core'
+import { useTimeoutFn } from '@vueuse/core'
 import EditButton from '~/components/Buttons/EditButton.vue'
 import BreadcrumbItem from '~/components/Breadcrumbs/BreadcrumbItem.vue'
 import ReportModal from '~/components/Spam/ReportModal.vue'
@@ -173,13 +173,21 @@ function submitSearch() {
   }
 }
 
-watchDebounced(searchQuery, (value) => {
-  const q = value.trim()
-  if (q) {
-    navigateTo({ path: searchPath.value, query: { q, type: currentSearchType.value } })
+// Debounce typing-driven navigation to /search, but navigate immediately when
+// clearing — debouncing a clear adds perceived latency for nothing, and the
+// explicit cancel() avoids a latent bug where typing "foo" then clearing
+// within 300ms would still fire the search navigation after the clear.
+const { start: scheduleSearch, stop: cancelSearch } = useTimeoutFn(() => {
+  navigateTo({ path: searchPath.value, query: { q: searchQuery.value.trim(), type: currentSearchType.value } })
+}, 300, { immediate: false })
+
+watch(searchQuery, (value) => {
+  cancelSearch()
+  if (value.trim()) {
+    scheduleSearch()
   }
   else if (route.path.endsWith('/search')) {
     navigateTo({ path: `/organizations/${route.params.oid}` })
   }
-}, { debounce: 300 })
+})
 </script>

--- a/pages/organizations/[oid]/dataservices.vue
+++ b/pages/organizations/[oid]/dataservices.vue
@@ -29,31 +29,37 @@
         </select>
       </div>
     </div>
-    <ul
-      v-if="results?.data.length"
-      class="space-y-4 p-0 list-none"
+    <LoadingBlock
+      v-slot="{ data: loaded }"
+      :status
+      :data="results"
     >
-      <li
-        v-for="dataservice in results.data"
-        :key="dataservice.id"
-        class="p-0"
+      <ul
+        v-if="loaded.data.length"
+        class="space-y-4 p-0 list-none"
       >
-        <DataserviceCard :dataservice />
-      </li>
-    </ul>
-    <Pagination
-      v-if="results && results.total > pageSize"
-      :page
-      :page-size="pageSize"
-      :total-results="results.total"
-      class="mt-4"
-      @change="(p: number) => page = p"
-    />
+        <li
+          v-for="dataservice in loaded.data"
+          :key="dataservice.id"
+          class="p-0"
+        >
+          <DataserviceCard :dataservice />
+        </li>
+      </ul>
+      <Pagination
+        v-if="loaded.total > pageSize"
+        :page
+        :page-size="pageSize"
+        :total-results="loaded.total"
+        class="mt-4"
+        @change="(p: number) => page = p"
+      />
+    </LoadingBlock>
   </div>
 </template>
 
 <script setup lang="ts">
-import { DataserviceCard, Pagination, defaultDataserviceSortOptions, type Dataservice, type Organization, type PaginatedArray } from '@datagouv/components-next'
+import { DataserviceCard, LoadingBlock, Pagination, defaultDataserviceSortOptions, type Dataservice, type Organization, type PaginatedArray } from '@datagouv/components-next'
 import { useRouteQuery } from '@vueuse/router'
 
 const props = defineProps<{
@@ -77,7 +83,8 @@ const params = computed(() => {
   return p
 })
 
-const { data: results } = await useAPI<PaginatedArray<Dataservice>>('/api/2/dataservices/search/', {
+const { data: results, status } = await useAPI<PaginatedArray<Dataservice>>('/api/2/dataservices/search/', {
   params,
+  lazy: true,
 })
 </script>

--- a/pages/organizations/[oid]/datasets.vue
+++ b/pages/organizations/[oid]/datasets.vue
@@ -29,31 +29,37 @@
         </select>
       </div>
     </div>
-    <ul
-      v-if="results?.data.length"
-      class="space-y-4 p-0 list-none"
+    <LoadingBlock
+      v-slot="{ data: loaded }"
+      :status
+      :data="results"
     >
-      <li
-        v-for="dataset in results.data"
-        :key="dataset.id"
-        class="p-0"
+      <ul
+        v-if="loaded.data.length"
+        class="space-y-4 p-0 list-none"
       >
-        <DatasetCard :dataset />
-      </li>
-    </ul>
-    <Pagination
-      v-if="results && results.total > pageSize"
-      :page
-      :page-size="pageSize"
-      :total-results="results.total"
-      class="mt-4"
-      @change="(p: number) => page = p"
-    />
+        <li
+          v-for="dataset in loaded.data"
+          :key="dataset.id"
+          class="p-0"
+        >
+          <DatasetCard :dataset />
+        </li>
+      </ul>
+      <Pagination
+        v-if="loaded.total > pageSize"
+        :page
+        :page-size="pageSize"
+        :total-results="loaded.total"
+        class="mt-4"
+        @change="(p: number) => page = p"
+      />
+    </LoadingBlock>
   </div>
 </template>
 
 <script setup lang="ts">
-import { DatasetCard, Pagination, defaultDatasetSortOptions, type Dataset, type Organization, type PaginatedArray } from '@datagouv/components-next'
+import { DatasetCard, LoadingBlock, Pagination, defaultDatasetSortOptions, type Dataset, type Organization, type PaginatedArray } from '@datagouv/components-next'
 import { useRouteQuery } from '@vueuse/router'
 
 const props = defineProps<{
@@ -77,7 +83,8 @@ const params = computed(() => {
   return p
 })
 
-const { data: results } = await useAPI<PaginatedArray<Dataset>>('/api/2/datasets/search/', {
+const { data: results, status } = await useAPI<PaginatedArray<Dataset>>('/api/2/datasets/search/', {
   params,
+  lazy: true,
 })
 </script>

--- a/pages/organizations/[oid]/reuses.vue
+++ b/pages/organizations/[oid]/reuses.vue
@@ -29,31 +29,37 @@
         </select>
       </div>
     </div>
-    <ul
-      v-if="results?.data.length"
-      class="space-y-4 p-0 list-none"
+    <LoadingBlock
+      v-slot="{ data: loaded }"
+      :status
+      :data="results"
     >
-      <li
-        v-for="reuse in results.data"
-        :key="reuse.id"
-        class="p-0"
+      <ul
+        v-if="loaded.data.length"
+        class="space-y-4 p-0 list-none"
       >
-        <ReuseHorizontalCard :reuse />
-      </li>
-    </ul>
-    <Pagination
-      v-if="results && results.total > pageSize"
-      :page
-      :page-size="pageSize"
-      :total-results="results.total"
-      class="mt-4"
-      @change="(p: number) => page = p"
-    />
+        <li
+          v-for="reuse in loaded.data"
+          :key="reuse.id"
+          class="p-0"
+        >
+          <ReuseHorizontalCard :reuse />
+        </li>
+      </ul>
+      <Pagination
+        v-if="loaded.total > pageSize"
+        :page
+        :page-size="pageSize"
+        :total-results="loaded.total"
+        class="mt-4"
+        @change="(p: number) => page = p"
+      />
+    </LoadingBlock>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ReuseHorizontalCard, Pagination, defaultReuseSortOptions, type Reuse, type Organization, type PaginatedArray } from '@datagouv/components-next'
+import { LoadingBlock, ReuseHorizontalCard, Pagination, defaultReuseSortOptions, type Reuse, type Organization, type PaginatedArray } from '@datagouv/components-next'
 import { useRouteQuery } from '@vueuse/router'
 
 const props = defineProps<{
@@ -77,7 +83,8 @@ const params = computed(() => {
   return p
 })
 
-const { data: results } = await useAPI<PaginatedArray<Reuse>>('/api/2/reuses/search/', {
+const { data: results, status } = await useAPI<PaginatedArray<Reuse>>('/api/2/reuses/search/', {
   params,
+  lazy: true,
 })
 </script>


### PR DESCRIPTION
When leaving a search (by blanking the search input or clicking on another tab) there was a flash/loading of an empty search before switching page.