### PR TITLE
fix: add missing optimize deps

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -240,18 +240,19 @@ export default defineNuxtConfig({
       // It must optimized them to be able to handle commonjs dependencies.
       // See https://vite.dev/guide/dep-pre-bundling.html#customizing-the-behavior
       include: [
-        'debug',
-        'extend',
+        'debug', // CJS
+        'extend', // CJS
         'highlight.js',
         'rehype-highlight',
-        'unist-util-find',
-        'unist-util-find-all-between',
+        'unist-util-find', // CJS
+        'unist-util-find-all-between', // CJS
         'vue',
         'vue-router',
-        'maplibre-gl',
+        'maplibre-gl', // CJS
         'geopf-extensions-openlayers',
-        'vue3-xml-viewer',
+        'vue3-xml-viewer', // CJS
         'uqr',
+        'pdfjs-dist',
       ],
       // `@datagouv/components-next` shouldn't be optimize otherwise its vue instance is not the same
       // as the one used in udata-front-kit. This cause errors with the `provide` / `inject` functions

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -253,6 +253,8 @@ export default defineNuxtConfig({
         'vue3-xml-viewer', // CJS
         'uqr',
         'pdfjs-dist',
+        '@vue/devtools-core',
+        '@vue/devtools-kit',
       ],
       // `@datagouv/components-next` shouldn't be optimize otherwise its vue instance is not the same
       // as the one used in udata-front-kit. This cause errors with the `provide` / `inject` functions


### PR DESCRIPTION
Copy/paste from:

```
ℹ Vite discovered new dependencies at runtime:                                                                                                                                           10:12:15
  pdfjs-dist ← ./datagouv-components/src/components/ResourceAccordion/PdfPreview.client.vue

Pre-bundle them in your nuxt.config.ts to avoid page reloads:

export default defineNuxtConfig({
  vite: {
    optimizeDeps: {
      include: [
        'debug', // CJS
        'extend', // CJS
        'highlight.js',
        'rehype-highlight',
        'unist-util-find', // CJS
        'unist-util-find-all-between', // CJS
        'vue',
        'vue-router',
        'maplibre-gl', // CJS
        'geopf-extensions-openlayers',
        'vue3-xml-viewer', // CJS
        'uqr',
        'pdfjs-dist',
      ]
    }
  }
})
```

and 

```
ℹ Vite discovered new dependencies at runtime:                                                                                                                                           06:28:22
  ./virtual:nuxt:%2Fhome%2Fthibaud%2FCode%2Fudata-workspace%2Fcdata%2F.nuxt%2Fruntime.vue-devtools-client.a_6LwWRBI5Gy2tSzt_v2jBxCp0CmLAl97X3XorKP1kY.js
    @vue/devtools-core
    @vue/devtools-kit

Pre-bundle them in your nuxt.config.ts to avoid page reloads:

export default defineNuxtConfig({
  vite: {
    optimizeDeps: {
      include: [
        'debug', // CJS
        'extend', // CJS
        'highlight.js',
        'rehype-highlight',
        'unist-util-find', // CJS
        'unist-util-find-all-between', // CJS
        'vue',
        'vue-router',
        'maplibre-gl', // CJS
        'geopf-extensions-openlayers',
        'vue3-xml-viewer', // CJS
        'uqr',
        '@vue/devtools-core',
        '@vue/devtools-kit',
      ]
    }
  }
})
```