### PR TITLE
chore(charts): make echarts optional 

### DIFF
--- a/components/Charts/ChartConfigurator.vue
+++ b/components/Charts/ChartConfigurator.vue
@@ -399,7 +399,7 @@ import { useAPI } from '~/utils/api'
 import ChartFilterRow from './ChartFilterRow.vue'
 import type { DatasetSuggest } from '~/types/types'
 
-const ChartViewerWrapper = defineAsyncComponent(() => import('@datagouv/components-next').then(m => m.ChartViewerWrapper))
+const ChartViewerWrapper = defineAsyncComponent(() => import('@datagouv/components-next/chart').then(m => m.ChartViewerWrapper))
 
 const form = defineModel<ChartForm>({
   required: true,

--- a/datagouv-components/package.json
+++ b/datagouv-components/package.json
@@ -17,6 +17,10 @@
     ]
   },
   "main": "./src/main.ts",
+  "exports": {
+    ".": "./src/main.ts",
+    "./chart": "./src/chart.ts"
+  },
   "sideEffects": false,
   "files": [
     "assets",

--- a/datagouv-components/package.json
+++ b/datagouv-components/package.json
@@ -20,7 +20,8 @@
   "exports": {
     ".": "./src/main.ts",
     "./chart": "./src/chart.ts",
-    "./assets/*": "./assets/*"
+    "./assets/*": "./assets/*",
+    "./dist/*": "./dist/*"
   },
   "sideEffects": false,
   "files": [

--- a/datagouv-components/package.json
+++ b/datagouv-components/package.json
@@ -19,7 +19,8 @@
   "main": "./src/main.ts",
   "exports": {
     ".": "./src/main.ts",
-    "./chart": "./src/chart.ts"
+    "./chart": "./src/chart.ts",
+    "./assets/*": "./assets/*"
   },
   "sideEffects": false,
   "files": [

--- a/datagouv-components/package.json
+++ b/datagouv-components/package.json
@@ -53,7 +53,6 @@
     "@vueuse/router": "^14.2.1",
     "chart.js": "^4.4.8",
     "dompurify": "^3.2.5",
-    "echarts": "^6.0.0",
     "geopf-extensions-openlayers": "^1.0.0-beta.10",
     "leaflet": "^1.9.4",
     "maplibre-gl": "^5.6.2",
@@ -94,6 +93,7 @@
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.3.0",
     "@vue/tsconfig": "^0.8.0",
+    "echarts": "^6.0.0",
     "eslint": "^9.18.0",
     "eslint-plugin-vue": "^10.0",
     "jiti": "^2.4.2",
@@ -110,7 +110,8 @@
   },
   "peerDependencies": {
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0 || ^5.0.0"
+    "vue-router": "^4.5.0 || ^5.0.0",
+    "echarts": "^6.0.0"
   },
   "scarfSettings": {
     "enabled": false

--- a/datagouv-components/src/chart.ts
+++ b/datagouv-components/src/chart.ts
@@ -1,0 +1,5 @@
+import ChartViewer from './components/Chart/ChartViewer.vue'
+import ChartViewerWrapper from './components/Chart/ChartViewerWrapper.vue'
+import SmallChart from './components/SmallChart.vue'
+
+export { ChartViewer, ChartViewerWrapper, SmallChart }

--- a/datagouv-components/src/main.ts
+++ b/datagouv-components/src/main.ts
@@ -82,9 +82,6 @@ import ReuseHorizontalCard from './components/ReuseHorizontalCard.vue'
 import ReuseDetails from './components/ReuseDetails.vue'
 import SchemaCard from './components/SchemaCard.vue'
 import SimpleBanner from './components/SimpleBanner.vue'
-import SmallChart from './components/SmallChart.vue'
-import ChartViewer from './components/Chart/ChartViewer.vue'
-import ChartViewerWrapper from './components/Chart/ChartViewerWrapper.vue'
 import StatBox from './components/StatBox.vue'
 import Tab from './components/Tabs/Tab.vue'
 import TabGroup from './components/Tabs/TabGroup.vue'
@@ -344,9 +341,6 @@ export {
   ReuseHorizontalCard,
   SchemaCard,
   SimpleBanner,
-  SmallChart,
-  ChartViewer,
-  ChartViewerWrapper,
   StatBox,
   OpenApiViewer,
   Tab,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,9 +248,6 @@ importers:
       dompurify:
         specifier: ^3.2.5
         version: 3.2.7
-      echarts:
-        specifier: ^6.0.0
-        version: 6.0.0
       geopf-extensions-openlayers:
         specifier: ^1.0.0-beta.10
         version: 1.0.0-beta.10
@@ -366,6 +363,9 @@ importers:
       '@vue/tsconfig':
         specifier: ^0.8.0
         version: 0.8.1(typescript@5.9.3)(vue@3.5.33(typescript@5.9.3))
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
       eslint:
         specifier: ^9.18.0
         version: 9.36.0(jiti@2.6.1)


### PR DESCRIPTION
Make `echarts` optional by declaring it as a peer dependency and using a dedicated entry point for its usage. Two benefits:

1. Downstream that doesn't need the echarts components does not install the huge library
2. Avoid downstream issues for local install of components. The chart components imports in `main.ts` will trigger vue deps analysis until `echarts` is reached, and it might not be installed (it's not in front-kit since we don't need it yet).

```
[plugin:vite:import-analysis] Failed to resolve import "echarts/core" from "node_modules/@datagouv/components-next/src/components/Chart/ChartViewer.vue". Does the file exist?
/Users/alexandre/Developer/Ecolab/Ecopshères/ecospheres-front/node_modules/@datagouv/components-next/src/components/Chart/ChartViewer.vue:9:48
12 |  /* Injection by vite-plugin-vue-inspector End */
13 |  import { defineComponent as _defineComponent } from "vue";
14 |  import { format, use } from "echarts/core";
   |                               ^
15 |  import { CanvasRenderer } from "echarts/renderers";
16 |  import { LineChart, BarChart } from "echarts/charts";
```

I went with a non-optional peer dep so that downstream gets a non-blocking warning inviting to install echarts if needed.