### PR TITLE
feat(search|a11y): announce results count, optional autofocus

### DIFF
--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -13,7 +13,7 @@
       <SearchInput
         v-model="q"
         :placeholder="resolvedPlaceholder"
-        :auto-focus="props.autoFocus"
+        :auto-focus
       />
     </div>
     <div class="grid grid-cols-12 mt-2 md:mt-5">

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -13,6 +13,7 @@
       <SearchInput
         v-model="q"
         :placeholder="resolvedPlaceholder"
+        :auto-focus="props.autoFocus"
       />
     </div>
     <div class="grid grid-cols-12 mt-2 md:mt-5">
@@ -401,9 +402,11 @@ const props = withDefaults(defineProps<{
   config?: GlobalSearchConfig
   placeholder?: string | null
   hideSearchInput?: boolean
+  autoFocus?: boolean
 }>(), {
   config: getDefaultGlobalSearchConfig,
   hideSearchInput: false,
+  autoFocus: true,
 })
 
 const emit = defineEmits<{

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -406,6 +406,10 @@ const props = withDefaults(defineProps<{
   hideSearchInput: false,
 })
 
+const emit = defineEmits<{
+  resultsCount: [total: number]
+}>()
+
 // defineModel's default is static and can't depend on props, so we cast and initialize manually
 const currentType = defineModel<string>('type') as Ref<string>
 if (!currentType.value) currentType.value = configKey(props.config[0] ?? { class: 'datasets' })
@@ -716,6 +720,10 @@ function resetFilters() {
 
 const searchResults = computed(() => resultsMap[currentType.value]?.data.value)
 const searchResultsStatus = computed(() => resultsMap[currentType.value]?.status.value)
+
+watch(searchResults, (results) => {
+  if (results) emit('resultsCount', results.total)
+}, { immediate: true })
 
 // RSS feed URL for datasets
 const rssUrl = computed(() => {

--- a/datagouv-components/src/components/Search/SearchInput.vue
+++ b/datagouv-components/src/components/Search/SearchInput.vue
@@ -37,7 +37,7 @@ import BrandedButton from '../BrandedButton.vue'
 
 const q = defineModel<string>({ required: true })
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   placeholder?: string | null
   autoFocus?: boolean
 }>(), {
@@ -57,6 +57,7 @@ const focus = () => {
 }
 
 onMounted(async () => {
+  if (!props.autoFocus) return
   await nextTick()
   focus()
 })


### PR DESCRIPTION
Two features to improve a11y downstream:
- optional autofocus on search input field (udata-front-kit focuses on a11y quick links)
- emit an event with results count (for screen readers announcements)