### PR TITLE
fix: sending credentials with new CORS policy

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -21,6 +21,7 @@
 import 'vue-sonner/style.css'
 import { Toaster, datagouv } from '@datagouv/components-next'
 import type { UseFetchFunction } from '@datagouv/components-next'
+import type { $Fetch } from 'ofetch'
 import CdataLink from './components/CdataLink.vue'
 import { ClientOnly, TextClamp } from '#components'
 
@@ -52,6 +53,7 @@ app.vueApp.use(datagouv, {
   tabularApiDataserviceId: runtimeConfig.public.tabularApiDataserviceId,
   tabularAllowRemote: true,
   customUseFetch: useAPI as UseFetchFunction, // Why this `as` is required?
+  $fetch: app.$api as $Fetch, // Imperative fetch for the lib's non-reactive helpers (metrics CSV export). Cast: Nuxt's $Fetch type lacks `native`, like the `as UseFetchFunction` above.
   textClamp: TextClamp,
   appLink: CdataLink,
   clientOnly: ClientOnly,

--- a/datagouv-components/src/composables/useMetrics.ts
+++ b/datagouv-components/src/composables/useMetrics.ts
@@ -13,6 +13,6 @@ export function useMetrics() {
     getDatasetMetrics: (datasetId: string) => getDatasetMetrics(datasetId, config.metricsApiUrl!),
     getDataserviceMetrics: (dataserviceId: string) => getDataserviceMetrics(dataserviceId, config.metricsApiUrl!),
     getReuseMetrics: (reuseId: string) => getReuseMetrics(reuseId, config.metricsApiUrl!),
-    createDatasetsForOrganizationMetricsUrl: (organizationId: string) => createDatasetsForOrganizationMetricsUrl(organizationId, config.metricsApiUrl!, config.apiBase),
+    createDatasetsForOrganizationMetricsUrl: (organizationId: string) => createDatasetsForOrganizationMetricsUrl(organizationId, config.metricsApiUrl!, config.apiBase, config.$fetch),
   }
 }

--- a/datagouv-components/src/config.ts
+++ b/datagouv-components/src/config.ts
@@ -1,6 +1,6 @@
 import { inject, type Component, type InjectionKey } from 'vue'
 import type { UseFetchFunction } from './functions/api.types'
-import type { FetchOptions } from 'ofetch'
+import type { $Fetch, FetchOptions } from 'ofetch'
 
 export type PluginConfig = {
   name: string // Name of the application (ex: data.gouv.fr)
@@ -25,6 +25,16 @@ export type PluginConfig = {
   tabularAllowRemote?: boolean
   tabularApiDataserviceId?: string
   customUseFetch?: UseFetchFunction | null
+  /**
+   * Imperative configured fetch (auth, headers, error handling): the single source of truth for
+   * requests. The default `useFetch` uses it as its transport, and imperative helpers (metrics CSV
+   * export, …) call it directly — so they never need a `?? ofetch` fallback.
+   * Optional for consumers: when omitted, the plugin defaults it to an `ofetch` instance built from
+   * the `onRequest`/`onResponse` hooks below (see the `datagouv` plugin install). A consumer can
+   * instead provide its own (e.g. a Bearer-authenticated `$fetch`) and skip the hooks entirely.
+   */
+  $fetch?: $Fetch | null
+  /** Auth/headers/error hooks. Folded into the default `$fetch` when no `$fetch` is provided. */
   onRequest?: FetchOptions['onRequest']
   onRequestError?: FetchOptions['onRequestError']
   onResponse?: FetchOptions['onResponse']
@@ -38,8 +48,12 @@ export type PluginConfig = {
 
 export const configKey = Symbol() as InjectionKey<PluginConfig>
 
-export function useComponentsConfig(): PluginConfig {
+// After the `datagouv` plugin install, `$fetch` is always set (defaulted to an ofetch instance), so
+// consumers of the config can rely on it without a fallback.
+export type ResolvedPluginConfig = PluginConfig & { $fetch: $Fetch }
+
+export function useComponentsConfig(): ResolvedPluginConfig {
   const config = inject(configKey)
   if (!config) throw new Error('Calling `useComponentsConfig` outside @datagouv/components')
-  return config
+  return config as ResolvedPluginConfig
 }

--- a/datagouv-components/src/functions/api.ts
+++ b/datagouv-components/src/functions/api.ts
@@ -1,7 +1,6 @@
 import { ref, toValue, watchEffect, onMounted, type ComputedRef, type MaybeRefOrGetter, type Ref } from 'vue'
 import { ofetch } from 'ofetch'
 import { useComponentsConfig } from '../config'
-import { useTranslation } from '../composables/useTranslation'
 import type { AsyncData, AsyncDataRequestStatus, UseFetchOptions } from './api.types'
 
 function deepToValue(obj: MaybeRefOrGetter<Record<string, unknown> | undefined>): Record<string, unknown> | undefined {
@@ -17,8 +16,6 @@ export async function useFetch<DataT, ErrorT = never>(
   options?: UseFetchOptions<DataT>,
 ): Promise<AsyncData<DataT, ErrorT>> {
   const config = useComponentsConfig()
-
-  const { locale } = useTranslation()
 
   if (config.customUseFetch) {
     return await config.customUseFetch(url, options)
@@ -37,38 +34,12 @@ export async function useFetch<DataT, ErrorT = never>(
     status.value = 'pending'
     try {
       data.value = isRaw
+        // Raw targets another data.gouv service (the Tabular API in TabularExplorer) via its own
+        // absolute URL, so it must stay bare ofetch: no datagouv apiBase, no datagouv auth attached.
         ? await ofetch<DataT | null>(urlValue, { params: params ?? query })
-        : await ofetch<DataT | null>(urlValue, {
-            baseURL: config.apiBase,
-            params: params ?? query,
-            onRequest(param) {
-              if (config.onRequest) {
-                if (Array.isArray(config.onRequest)) {
-                  config.onRequest.forEach(r => r(param))
-                }
-                else {
-                  config.onRequest(param)
-                }
-              }
-              const { options } = param
-              options.headers.set('Content-Type', 'application/json')
-              options.headers.set('Accept', 'application/json')
-              options.credentials = 'include'
-              if (config.devApiKey) {
-                options.headers.set('X-API-KEY', config.devApiKey)
-              }
-
-              if (locale) {
-                if (!options.params) {
-                  options.params = {}
-                }
-                options.params['lang'] = locale
-              }
-            },
-            onRequestError: config.onRequestError,
-            onResponse: config.onResponse,
-            onResponseError: config.onResponseError,
-          })
+        // The configured `$fetch` carries baseURL + auth + headers (see the `datagouv` plugin install
+        // for the default one). We only forward the URL and params here.
+        : await config.$fetch<DataT | null>(urlValue, { baseURL: config.apiBase, params: params ?? query })
       status.value = 'success'
     }
     catch (e) {

--- a/datagouv-components/src/functions/metrics.ts
+++ b/datagouv-components/src/functions/metrics.ts
@@ -1,5 +1,5 @@
 import { escapeCsvValue } from './helpers'
-import { ofetch } from 'ofetch'
+import { ofetch, type $Fetch } from 'ofetch'
 import type { DatasetV2 } from '../types/datasets'
 import type { PaginatedArray } from '../types/api'
 
@@ -119,14 +119,16 @@ export async function getDatasetMetrics(datasetId: string, metricsApi: string): 
   }
 }
 
-export async function createDatasetsForOrganizationMetricsUrl(organizationId: string, metricsApi: string, apiBase: string) {
+export async function createDatasetsForOrganizationMetricsUrl(organizationId: string, metricsApi: string, apiBase: string, apiFetch: $Fetch) {
   let data = 'dataset_title,dataset_id,month,monthly_visit,monthly_download_resource\n'
 
-  // fetch datasets info from organization datasets
+  // fetch datasets info from organization datasets through the configured fetch, so it carries the
+  // consumer's auth (cookie for cdata via `$api`, Bearer for verticals) instead of a hardcoded
+  // `credentials: 'include'`, which breaks CORS cross-origin on the verticals.
   const datasets: Record<string, Record<string, string>> = {}
   let datasetsUrl: string | null = `/api/2/datasets/?organization=${organizationId}&page_size=200`
   while (datasetsUrl) {
-    const body: PaginatedArray<DatasetV2> = await ofetch(datasetsUrl, { baseURL: apiBase, credentials: 'include' })
+    const body: PaginatedArray<DatasetV2> = await apiFetch(datasetsUrl, { baseURL: apiBase })
     datasetsUrl = body.next_page
     for (const row of body.data) {
       datasets[row.id] = { title: row.title }

--- a/datagouv-components/src/main.ts
+++ b/datagouv-components/src/main.ts
@@ -104,6 +104,8 @@ import InfiniteLoader from './components/InfiniteLoader.vue'
 import TabularExplorer from './components/TabularExplorer/TabularExplorer.vue'
 import type { UseFetchFunction } from './functions/api.types'
 import { configKey, useComponentsConfig, type PluginConfig } from './config.js'
+import { ofetch } from 'ofetch'
+import { useTranslation } from './composables/useTranslation'
 
 export { Toaster, toast } from 'vue-sonner'
 
@@ -278,6 +280,31 @@ export {
 // Vue Plugin
 const datagouv: Plugin<PluginConfig> = {
   async install(app: App, options) {
+    // Default `$fetch` to an ofetch instance carrying the datagouv API specifics + the consumer's
+    // auth hooks, so everything downstream (the default `useFetch`, imperative helpers) can rely on
+    // a single configured fetch. A consumer that provides its own `$fetch` keeps full control.
+    if (!options.$fetch) {
+      options.$fetch = ofetch.create({
+        baseURL: options.apiBase,
+        onRequest(context) {
+          if (options.onRequest) {
+            if (Array.isArray(options.onRequest)) options.onRequest.forEach(hook => hook(context))
+            else options.onRequest(context)
+          }
+          context.options.headers.set('Content-Type', 'application/json')
+          context.options.headers.set('Accept', 'application/json')
+          if (options.devApiKey) context.options.headers.set('X-API-KEY', options.devApiKey)
+          const { locale } = useTranslation()
+          if (locale) {
+            context.options.params ??= {}
+            context.options.params['lang'] = locale
+          }
+        },
+        onRequestError: options.onRequestError,
+        onResponse: options.onResponse,
+        onResponseError: options.onResponseError,
+      })
+    }
     app.provide(configKey, options)
     if (!options.textClamp) {
       const textClamp = await import('vue3-text-clamp')

--- a/error.vue
+++ b/error.vue
@@ -160,6 +160,7 @@
 <script setup lang="ts">
 import { datagouv, BrandedButton, CopyButton } from '@datagouv/components-next'
 import type { UseFetchFunction } from '@datagouv/components-next'
+import type { $Fetch } from 'ofetch'
 import CdataLink from './components/CdataLink.vue'
 import { ClientOnly, TextClamp } from '#components'
 import error404Svg from '~/public/nuxt_images/errors/404.svg'
@@ -189,6 +190,7 @@ app.vueApp.use(datagouv, {
   tabularAllowRemote: true,
   datasetQualityGuideUrl: runtimeConfig.public.datasetQualityGuideUrl,
   customUseFetch: useAPI as UseFetchFunction, // Why this `as` is required?
+  $fetch: app.$api as $Fetch, // Imperative fetch for the lib's non-reactive helpers (metrics CSV export). Cast: Nuxt's $Fetch type lacks `native`, like the `as UseFetchFunction` above.
   textClamp: TextClamp,
   appLink: CdataLink,
   clientOnly: ClientOnly,


### PR DESCRIPTION
## Fix broken CORS on udata-front-kit verticals + unify the configured fetch

### Problem

The backend (`udata`) hardened its CORS handling: only trusted origins (the cdata front) now receive `Access-Control-Allow-Origin: <origin>` + `Access-Control-Allow-Credentials: true`. Any other origin — e.g. the `udata-front-kit` verticals (`simplifions`, `écosphères`…) — now gets `Access-Control-Allow-Origin: *` without credentials.

`datagouv-components`' default fetch sent every request with `credentials: 'include'`, and the browser forbids `Access-Control-Allow-Origin: *` together with `credentials: 'include'`. As a result, every component request from the verticals (e.g. `GlobalSearch` hitting `/api/2/topics/search/`) failed with:

> The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.

The verticals authenticate via an `Authorization: Bearer` header, not the cookie, so `credentials: 'include'` was both useless and harmful for them. cdata itself was unaffected (it provides a `customUseFetch` and is a trusted origin).

### Changes (`datagouv-components`)

- **Removed the hardcoded `credentials: 'include'`** from the default `useFetch` and from the metrics CSV export (`createDatasetsForOrganizationMetricsUrl`), which were the two shared code paths breaking CORS cross-origin.
- **Introduced a single configured `$fetch`** in the plugin config, the single source of truth for requests (auth, headers, error handling):
  - The plugin `install` defaults it to an `ofetch` instance built from the existing `onRequest`/`onResponse` config hooks (baseURL, JSON headers, `X-API-KEY`, `lang`, plus the consumer's hooks). So `config.$fetch` is **always defined**, and `useComponentsConfig()` types it as non-optional — no `?? ofetch` fallback needed at any call site.
  - The default `useFetch` now just delegates to `config.$fetch` (the per-call `onRequest` layer is gone from `api.ts`). `raw` requests stay on bare `ofetch` since they target another data.gouv service (the Tabular API) with its own absolute URL.
  - Imperative helpers (metrics CSV export) call `config.$fetch` directly.

### Changes (cdata)

- `app.vue` / `error.vue` now pass `$fetch: $api` alongside the existing `customUseFetch: useAPI`, so the metrics CSV export goes through cdata's authenticated `$api` (cookie + token + error handling) instead of a raw cookie-based `ofetch`.

### Backward compatibility

Non-breaking. Verticals that still configure `onRequest` (their Bearer injection) keep working unchanged: the `install` folds those hooks into the default `$fetch`. They can later switch to providing their own `$fetch` and drop the hooks, but it's not required.