### PR TITLE
fix: use reuses x-fields in reuses tab

### DIFF
--- a/pages/datasets/[did]/reuses_and_dataservices.vue
+++ b/pages/datasets/[did]/reuses_and_dataservices.vue
@@ -112,5 +112,11 @@ const reusesQuery = computed(() => ({
   page: reusesPage.value,
   page_size: 6,
 }))
-const { data: reuses } = await useAPI<PaginatedArray<Reuse>>('/api/1/reuses', { query: reusesQuery })
+
+const { data: reuses } = await useAPI<PaginatedArray<Reuse>>('/api/1/reuses', {
+  query: reusesQuery,
+  headers: {
+    'X-Fields': reusesXFields,
+  },
+})
 </script>


### PR DESCRIPTION
This PR prevent the reuses tab on the dataset page to fetch the dataset data every time and all its ressources