### PR TITLE
chore: use NODE_ENV production in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,7 @@ WORKDIR /app
 # Copy only .output (pre-built by CI)
 COPY .output/ .output/
 
+ENV NODE_ENV=production
+
 EXPOSE 3000
 CMD [ "node", ".output/server/index.mjs" ]


### PR DESCRIPTION
I was looking at https://github.com/datagouv/data.gouv.fr/issues/2015 and the vue-router logic.
vue-router source code is easily readable and everywhere I found that the warn are wrapped around "dev" checks.

I try to reproduce locally in dev mode, got the warnings, and with `preview`.
And I didn't get any warning at all in preview.

It turns out that the preview script is adding the env somewhere, but it's not done in our Dockerfile as[ it should be](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#environment-variables).