### PR TITLE
feat(search): restrict org filter to orgs with an API on dataservices…

### DIFF
--- a/datagouv-components/src/components/Form/OrganizationSelect.vue
+++ b/datagouv-components/src/components/Form/OrganizationSelect.vue
@@ -36,8 +36,9 @@ import SearchableSelect from './SearchableSelect.vue'
 const model = defineModel<Organization | OrganizationSuggest | null>({ default: null })
 const id = defineModel<string | undefined>('id')
 
-defineProps<{
+const props = defineProps<{
   loading?: boolean
+  dataservices?: boolean
 }>()
 
 const config = useComponentsConfig()
@@ -56,6 +57,7 @@ async function suggestOrganizations(q: string): Promise<Array<Organization | Org
     query: {
       q,
       size: 20,
+      ...(props.dataservices ? { dataservices: true } : {}),
     },
   })
 }

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -61,6 +61,7 @@
               <OrganizationSelect
                 v-if="isEnabled('organization')"
                 v-model:id="organizationId"
+                :dataservices="currentTypeConfig?.class === 'dataservices'"
                 :style="{ order: getOrder('organization') }"
               />
               <OrganizationTypeSelect


### PR DESCRIPTION
… search

Pass dataservices=true to the org suggest endpoint when the active search is the dataservices (API) search, so the organization filter only offers orgs that have at least one API. Implements API2-314 (frontend half).

fix https://linear.app/pole-api/issue/API2-314/retirer-les-organisations-par-defaut-du-filtre-organisation-lorsque

linked with https://github.com/opendatateam/udata/pull/3804
