### PR TITLE
feat(search): customizable type icons

### DIFF
--- a/datagouv-components/src/components/RadioInput.vue
+++ b/datagouv-components/src/components/RadioInput.vue
@@ -13,8 +13,13 @@
     >
     <component
       :is="icon"
-      v-if="icon"
+      v-if="icon && typeof icon !== 'string'"
       class="w-4 h-4"
+    />
+    <span
+      v-else-if="icon"
+      :class="icon"
+      aria-hidden="true"
     />
     <span class="text-sm flex-1 min-w-0">
       <slot />
@@ -40,7 +45,7 @@ type Props = {
   value: string
   count?: number
   loading?: boolean
-  icon?: Component
+  icon?: Component | string
   highlighted?: boolean
 }
 

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -36,7 +36,7 @@
                 :value="configKey(typeConfig)"
                 :count="resultsMap[configKey(typeConfig)]?.data.value?.total"
                 :loading="resultsMap[configKey(typeConfig)]?.status.value === 'pending' || resultsMap[configKey(typeConfig)]?.status.value === 'idle'"
-                :icon="strategies[typeConfig.class].icon"
+                :icon="typeConfig.icon ?? strategies[typeConfig.class].icon"
               >
                 {{ typeConfig.name || strategies[typeConfig.class].name }}
               </RadioInput>

--- a/datagouv-components/src/types/search.ts
+++ b/datagouv-components/src/types/search.ts
@@ -1,3 +1,4 @@
+import type { Component } from 'vue'
 import type { PaginatedArray } from './api'
 import type { AccessType } from './access_types'
 import type { Dataset } from './datasets'
@@ -298,6 +299,7 @@ export type DatasetSearchConfig = {
   class: 'datasets'
   key?: string
   name?: string
+  icon?: Component | string
   placeholder?: string | null
   hiddenFilters?: HiddenFilter<DatasetSearchFilters>[]
   basicFilters?: (keyof DatasetSearchFilters)[]
@@ -309,6 +311,7 @@ export type DataserviceSearchConfig = {
   class: 'dataservices'
   key?: string
   name?: string
+  icon?: Component | string
   placeholder?: string | null
   hiddenFilters?: HiddenFilter<DataserviceSearchFilters>[]
   basicFilters?: (keyof DataserviceSearchFilters)[]
@@ -320,6 +323,7 @@ export type ReuseSearchConfig = {
   class: 'reuses'
   key?: string
   name?: string
+  icon?: Component | string
   placeholder?: string | null
   hiddenFilters?: HiddenFilter<ReuseSearchFilters>[]
   basicFilters?: (keyof ReuseSearchFilters)[]
@@ -331,6 +335,7 @@ export type OrganizationSearchConfig = {
   class: 'organizations'
   key?: string
   name?: string
+  icon?: Component | string
   placeholder?: string | null
   hiddenFilters?: HiddenFilter<OrganizationSearchFilters>[]
   basicFilters?: (keyof OrganizationSearchFilters)[]
@@ -342,6 +347,7 @@ export type TopicSearchConfig = {
   class: 'topics'
   key?: string
   name?: string
+  icon?: Component | string
   placeholder?: string | null
   hiddenFilters?: HiddenFilter<TopicSearchFilters>[]
   basicFilters?: (keyof TopicSearchFilters)[]


### PR DESCRIPTION
Lets downstream pass an icon to the types list of GlobalSearch. The icon can be a string (we're not using RemixIcons in the front-kit, so we just pass a dsfr icon class name).