### PR TITLE
fix: hide stats download without datasets

### DIFF
--- a/components/Datasets/AdminDatasetsPage.vue
+++ b/components/Datasets/AdminDatasetsPage.vue
@@ -43,8 +43,8 @@
         />
         <div>
           <BrandedButton
-            v-if="organization"
-            :href="pageData.total ? `${config.public.apiBase}/api/1/organizations/${organization.id}/datasets.csv` : undefined"
+            v-if="organization && organization.metrics.datasets > 0"
+            :href="`${config.public.apiBase}/api/1/organizations/${organization.id}/datasets.csv`"
             size="xs"
             :external="true"
             :icon="RiDownloadLine"
@@ -56,14 +56,14 @@
     </div>
 
     <LoadingBlock
-      v-slot="{ data: pageData }"
+      v-slot="{ data }"
       :status
       :data="pageData"
     >
-      <div v-if="pageData && pageData.total > 0">
+      <div v-if="data && data.total > 0">
         <AdminDatasetsTable
           :activities="datasetActivities"
-          :datasets="pageData ? pageData.data : []"
+          :datasets="data.data"
           :sort-direction="direction"
           :sorted-by
           @sort="sort"
@@ -71,7 +71,7 @@
         <Pagination
           :page="page"
           :page-size="pageSize"
-          :total-results="pageData.total"
+          :total-results="data.total"
           @change="(changedPage: number) => page = changedPage"
         />
       </div>

--- a/components/Metrics/AdminDatasetsPage.vue
+++ b/components/Metrics/AdminDatasetsPage.vue
@@ -8,7 +8,7 @@
         :placeholder="$t('Recherche')"
       />
       <BrandedButton
-        v-if="organization"
+        v-if="organization && organization.metrics.datasets > 0"
         size="xs"
         :icon="RiDownloadLine"
         :loading="isDownloadingStats"
@@ -17,7 +17,7 @@
         {{ isDownloadingStats ? $t('Téléchargement de l\'évolution par mois...') : $t('Télécharger l\'évolution par mois') }}
       </BrandedButton>
       <BrandedButton
-        v-if="downloadCatalogsUrl"
+        v-if="organization && organization.metrics.datasets > 0 && downloadCatalogsUrl"
         color="secondary"
         :href="downloadCatalogsUrl"
         :external="true"


### PR DESCRIPTION
Fixes #958

When an organization has no datasets, download buttons on the metrics and datasets admin pages are now hidden instead of offering empty CSV downloads or 404 responses.

