### PR TITLE
feat(search): customizable defaultSort

### DIFF
--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -200,10 +200,13 @@
               <div class="fr-col">
                 <select
                   id="sort-search"
-                  v-model="sort"
+                  v-model="effectiveSort"
                   class="fr-select text-sm shadow-input-blue!"
                 >
-                  <option :value="undefined">
+                  <option
+                    v-if="!currentTypeConfig?.defaultSort"
+                    :value="undefined"
+                  >
                     {{ t('Pertinence') }}
                   </option>
                   <option
@@ -489,6 +492,10 @@ const { debounced: qDebounced, flush: flushQ } = useDebouncedRef(q, componentsCo
 const qForParams = computed(() => props.hideSearchInput ? q.value : qDebounced.value)
 const page = useRouteQuery('page', 1, { transform: Number })
 const sort = useRouteQuery<string | undefined>('sort')
+const effectiveSort = computed({
+  get: () => sort.value ?? currentTypeConfig.value?.defaultSort,
+  set: (value) => { sort.value = value },
+})
 
 provide(searchFilterContextKey, {
   register(urlParam, entry) {
@@ -759,7 +766,7 @@ const rssUrl = computed(() => {
   }, currentTypeConfig.value ? configKey(currentTypeConfig.value) : undefined)
 
   // Add sort if set
-  if (sort.value) params.set('sort', sort.value)
+  if (effectiveSort.value) params.set('sort', effectiveSort.value)
 
   const queryString = params.toString()
   const basePath = '/api/1/datasets/recent.atom'

--- a/datagouv-components/src/composables/useStableQueryParams.ts
+++ b/datagouv-components/src/composables/useStableQueryParams.ts
@@ -72,10 +72,11 @@ export function useStableQueryParams(options: StableQueryParamsOptions) {
     if (q.value) {
       params.q = q.value
     }
-    if (sort.value) {
+    const sortToUse = sort.value ?? typeConfig?.defaultSort
+    if (sortToUse) {
       const validSortValues = typeConfig?.sortOptions?.map(o => o.value as string) ?? []
-      if (validSortValues.includes(sort.value)) {
-        params.sort = sort.value
+      if (validSortValues.includes(sortToUse)) {
+        params.sort = sortToUse
       }
     }
     params.page = page.value

--- a/datagouv-components/src/composables/useStableQueryParams.ts
+++ b/datagouv-components/src/composables/useStableQueryParams.ts
@@ -78,6 +78,9 @@ export function useStableQueryParams(options: StableQueryParamsOptions) {
       if (validSortValues.includes(sortToUse)) {
         params.sort = sortToUse
       }
+      else if (import.meta.env.DEV && typeConfig?.defaultSort && typeConfig?.sortOptions && sortToUse === typeConfig.defaultSort) {
+        console.warn(`[GlobalSearch] defaultSort "${typeConfig.defaultSort}" is not in sortOptions for "${typeConfig.class}". Valid values: ${validSortValues.join(', ')}`)
+      }
     }
     params.page = page.value
     params.page_size = pageSize

--- a/datagouv-components/src/types/search.ts
+++ b/datagouv-components/src/types/search.ts
@@ -303,6 +303,7 @@ export type DatasetSearchConfig = {
   basicFilters?: (keyof DatasetSearchFilters)[]
   advancedFilters?: (keyof DatasetSearchFilters)[]
   sortOptions?: SortOption<DatasetSearchSort>[]
+  defaultSort?: DatasetSearchSort
 }
 
 export type DataserviceSearchConfig = {
@@ -314,6 +315,7 @@ export type DataserviceSearchConfig = {
   basicFilters?: (keyof DataserviceSearchFilters)[]
   advancedFilters?: (keyof DataserviceSearchFilters)[]
   sortOptions?: SortOption<DataserviceSearchSort>[]
+  defaultSort?: DataserviceSearchSort
 }
 
 export type ReuseSearchConfig = {
@@ -325,6 +327,7 @@ export type ReuseSearchConfig = {
   basicFilters?: (keyof ReuseSearchFilters)[]
   advancedFilters?: (keyof ReuseSearchFilters)[]
   sortOptions?: SortOption<ReuseSearchSort>[]
+  defaultSort?: ReuseSearchSort
 }
 
 export type OrganizationSearchConfig = {
@@ -336,6 +339,7 @@ export type OrganizationSearchConfig = {
   basicFilters?: (keyof OrganizationSearchFilters)[]
   advancedFilters?: (keyof OrganizationSearchFilters)[]
   sortOptions?: SortOption<OrganizationSearchSort>[]
+  defaultSort?: OrganizationSearchSort
 }
 
 export type TopicSearchConfig = {
@@ -347,6 +351,7 @@ export type TopicSearchConfig = {
   basicFilters?: (keyof TopicSearchFilters)[]
   advancedFilters?: (keyof TopicSearchFilters)[]
   sortOptions?: SortOption<TopicSearchSort>[]
+  defaultSort?: TopicSearchSort
 }
 
 export type SearchTypeConfig = DatasetSearchConfig | DataserviceSearchConfig | ReuseSearchConfig | OrganizationSearchConfig | TopicSearchConfig


### PR DESCRIPTION
This lets the downstream component set a `defaultSort` for a given type.

I chose to hide the default Pertinence option when a `defaultSort` is set. This avoids having to handle a new `relevance` placeholder value for this sort order: it currently uses `undefined` and would clash with `sort = undefined ?? defaultSort`. YMMV, not a problem downstream for now.