### PR TITLE
feat: remove creation date and add base url into dataservice sidebar

### DIFF
--- a/pages/dataservices/[did].vue
+++ b/pages/dataservices/[did].vue
@@ -143,6 +143,25 @@
                 </h3>
                 <dl class="space-y-2.5 pl-0">
                   <div
+                    v-if="dataservice.base_api_url"
+                    class="space-y-1"
+                  >
+                    <dt class="text-gray-plain font-bold">
+                      {{ $t(`URL de base de l'API`) }}
+                    </dt>
+                    <dd class="p-0 m-0">
+                      <a
+                        :href="dataservice.base_api_url"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="link block truncate"
+                      >
+                        {{ dataservice.base_api_url }}
+                      </a>
+                    </dd>
+                  </div>
+
+                  <div
                     v-if="dataservice.rate_limiting || dataservice.rate_limiting_url"
                     class="space-y-1"
                   >

--- a/pages/dataservices/[did].vue
+++ b/pages/dataservices/[did].vue
@@ -180,24 +180,6 @@
                       </span>
                     </dd>
                   </div>
-
-                  <div class="space-y-1">
-                    <dt class="text-gray-plain font-bold">
-                      {{ $t('Dernière mise à jour') }}
-                    </dt>
-                    <dd class="p-0 m-0">
-                      {{ formatDate(dataservice.metadata_modified_at) }}
-                    </dd>
-                  </div>
-
-                  <div class="space-y-1">
-                    <dt class="text-gray-plain font-bold">
-                      {{ $t('Date de création') }}
-                    </dt>
-                    <dd class="p-0 m-0">
-                      {{ formatDate(dataservice.created_at) }}
-                    </dd>
-                  </div>
                 </dl>
                 <div class="flex flex-wrap gap-2 pt-1">
                   <BrandedButton
@@ -305,7 +287,7 @@
 </template>
 
 <script setup lang="ts">
-import { isOrganizationCertified, BrandedButton, LoadingBlock, OpenApiViewer, ReadMore, SimpleBanner, type Dataservice, AvatarWithName, useFormatDate, MarkdownViewer, getDescriptionShort } from '@datagouv/components-next'
+import { isOrganizationCertified, BrandedButton, LoadingBlock, OpenApiViewer, ReadMore, SimpleBanner, type Dataservice, AvatarWithName, MarkdownViewer, getDescriptionShort } from '@datagouv/components-next'
 import { RiArrowDownSLine, RiArrowUpSLine, RiDeleteBinLine, RiLockLine } from '@remixicon/vue'
 import AdminBadge from '~/components/AdminBadge/AdminBadge.vue'
 import EditButton from '~/components/Buttons/EditButton.vue'
@@ -322,7 +304,6 @@ definePageMeta({
 
 const config = useRuntimeConfig()
 const route = useRoute()
-const { formatDate } = useFormatDate()
 const { $matomo } = useNuxtApp()
 
 const sidebar = useTemplateRef('sidebar')

--- a/tests/dataservices/[did].spec.ts
+++ b/tests/dataservices/[did].spec.ts
@@ -22,6 +22,10 @@ test('sidebar displays correct metadata values', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Caractéristiques techniques' })).toBeVisible()
 
   // Technical block
+  await expect(page.getByText(`URL de base de l'API`)).toBeVisible()
+  await expect(
+    page.locator('aside a[href="https://opendata.caissedesdepots.fr/api/explore/v2.1/"]'),
+  ).toBeVisible()
   await expect(page.getByText('Taux de disponibilité')).toBeVisible()
   await expect(page.getByText('Non communiqué')).toBeVisible()
 })

--- a/tests/dataservices/[did].spec.ts
+++ b/tests/dataservices/[did].spec.ts
@@ -22,9 +22,6 @@ test('sidebar displays correct metadata values', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Caractéristiques techniques' })).toBeVisible()
 
   // Technical block
-  await expect(page.getByText('Dernière mise à jour')).toBeVisible()
-  await expect(page.getByText('30 juillet 2024')).toBeVisible()
-  await expect(page.getByText('Date de création')).toBeVisible()
   await expect(page.getByText('Taux de disponibilité')).toBeVisible()
   await expect(page.getByText('Non communiqué')).toBeVisible()
 })


### PR DESCRIPTION
- Removal: "date creation / mise à jour" on the sidebar (often wrong + already present in "informations techniques"
- Added "url de base" as per european recommendations

fix https://linear.app/pole-api/issue/API2-296/determiner-sil-faut-afficher-url-de-base-de-lapi-dans-la-fiche
fix https://linear.app/pole-api/issue/API2-381/modifier-le-label-et-laide-du-champ-url-de-base-de-lapi-dans-lespace