### PR TITLE
Feat: allow markdown on rate limiting field

### DIFF
--- a/pages/dataservices/[did].vue
+++ b/pages/dataservices/[did].vue
@@ -150,10 +150,10 @@
                       {{ $t(`Limite d'appels`) }}
                     </dt>
                     <dd class="p-0 m-0">
-                      <span
+                      <MarkdownViewer
                         v-if="dataservice.rate_limiting"
-                        class="mr-1"
-                      >{{ dataservice.rate_limiting }}</span>
+                        :content="dataservice.rate_limiting"
+                      />
                       <a
                         v-if="dataservice.rate_limiting_url"
                         :href="dataservice.rate_limiting_url"


### PR DESCRIPTION
fix https://linear.app/pole-api/issue/API-6848/formater-correctement-les-liens-dans-les-champs-limite-dappels-et-taux