### PR TITLE
fix(perfs): remove duplicate API calls in new_explorer=1

### DIFF
--- a/components/Datasets/LegacyResourceList.vue
+++ b/components/Datasets/LegacyResourceList.vue
@@ -157,10 +157,4 @@ watchEffect(async () => {
     selectedResource.value = null
   }
 })
-
-if (import.meta.server && hasResourceId.value) {
-  useSeoMeta({
-    robots: 'noindex',
-  })
-}
 </script>

--- a/components/Datasets/LegacyResourceList.vue
+++ b/components/Datasets/LegacyResourceList.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="space-y-5">
+    <div
+      v-if="selectedResource"
+      ref="selectedResourceBannerRef"
+      class="space-y-4"
+    >
+      <SimpleBanner
+
+        type="primary"
+        class="flex justify-between items-center"
+      >
+        <p class="!mb-0">
+          {{ $t('Vous consultez une resource spécifique.') }}
+        </p>
+        <BrandedButton
+          color="tertiary"
+          keep-margins-even-without-borders
+          :icon="RiCloseCircleLine"
+          :href="{ name: route.name, params: route.params, query: { ...route.query, resource_id: undefined } }"
+        >
+          {{ $t("Voir toutes les resources") }}
+        </BrandedButton>
+      </SimpleBanner>
+      <ResourceAccordion
+        :dataset
+        :resource="selectedResource"
+        expanded-on-mount
+        :can-edit="dataset.permissions.edit_resources"
+      />
+    </div>
+
+    <div
+      v-for="{ data, status }, index in resourcesByTypes"
+      v-else
+      :key="RESOURCE_TYPE[index]"
+      class="space-y-1"
+    >
+      <div
+        v-if="data.value"
+        class="uppercase text-gray-plain text-sm font-bold"
+      >
+        {{ getResourceLabel(RESOURCE_TYPE[index], data.value.total) }}
+      </div>
+      <div class="space-y-2.5">
+        <SearchInput
+          v-if="data.value && (data.value.total > data.value.page_size || searchByResourceType[index].value)"
+          v-model="searchByResourceType[index].value"
+          :placeholder="$t('Rechercher')"
+        />
+        <LoadingBlock
+          v-slot="{ data: resourcesData }"
+          :status="status.value"
+          :data="data.value"
+        >
+          <div class="space-y-2.5">
+            <ResourceAccordion
+              v-for="resource in resourcesData.data"
+              :key="resource.id"
+              :dataset
+              :resource
+              :can-edit="dataset.permissions.edit_resources"
+            />
+            <Pagination
+              :total-results="resourcesData.total"
+              :page-size="resourcesData.page_size"
+              :page="resourcesData.page"
+              @change="(newPage) => pageByResourceType[index].value = newPage"
+            />
+          </div>
+          <div
+            v-if="!resourcesData.total"
+            class="flex flex-col items-center"
+          >
+            <img
+              src="/illustrations/dataset.svg"
+              class="h-20"
+              alt=""
+            >
+            <p class="fr-text--bold fr-my-3v">
+              {{ $t(`Pas de résultats pour « {q} »`, { q: searchByResourceType[index].value }) }}
+            </p>
+            <BrandedButton
+              color="primary"
+              @click="searchByResourceType[index].value = ''"
+            >
+              {{ $t('Réinitialiser les filtres') }}
+            </BrandedButton>
+          </div>
+        </LoadingBlock>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { BrandedButton, getResourceLabel, LoadingBlock, Pagination, RESOURCE_TYPE, ResourceAccordion, SearchInput, SimpleBanner, type DatasetV2, type Resource } from '@datagouv/components-next'
+import { RiCloseCircleLine } from '@remixicon/vue'
+import { refDebounced } from '@vueuse/core'
+import type { PaginatedArray } from '~/types/types'
+
+const props = defineProps<{ dataset: DatasetV2 }>()
+
+const config = useRuntimeConfig()
+const route = useRoute()
+
+const url = computed(() => `/api/2/datasets/${props.dataset.id}/resources/`)
+const pageSize = ref(10)
+
+const pageByResourceType: Array<Ref<number>> = RESOURCE_TYPE.map(() => ref(1))
+const searchByResourceType: Array<Ref<string>> = RESOURCE_TYPE.map(() => ref(''))
+const searchDebouncedByResourceType: Array<Ref<string>> = searchByResourceType.map(ref => refDebounced(ref, config.public.searchDebounce))
+
+watch(searchByResourceType, (newQueries, oldQueries) => {
+  for (const index in newQueries) {
+    if (newQueries[index] != oldQueries[index]) {
+      pageByResourceType[index].value = 1
+    }
+  }
+})
+
+const queryParamsByResourceType = RESOURCE_TYPE.map((type, index) => {
+  return computed(() => ({
+    type,
+    page_size: pageSize.value,
+    page: pageByResourceType[index].value,
+    q: searchDebouncedByResourceType[index].value,
+  }))
+})
+
+const rawResourcesByTypes = await Promise.all(
+  RESOURCE_TYPE.map((type, index) => useAPI<PaginatedArray<Resource>>(url, { query: queryParamsByResourceType[index] })),
+)
+
+const resourcesByTypes = computed(() => {
+  const result = {} as Record<number, typeof rawResourcesByTypes[number]>
+  for (let i = 0; i < rawResourcesByTypes.length; i++) {
+    if ((rawResourcesByTypes[i].data.value?.total ?? 0) > 0 || searchByResourceType[i].value) {
+      result[i] = rawResourcesByTypes[i]
+    }
+  }
+  return result
+})
+
+const hasResourceId = computed(() => 'resource_id' in route.query && route.query.resource_id)
+const { $api } = useNuxtApp()
+const selectedResource = ref<Resource | null>(null)
+const selectedResourceBanner = useTemplateRef('selectedResourceBannerRef')
+watchEffect(async () => {
+  if (hasResourceId.value) {
+    selectedResource.value = await $api<Resource>(`/api/1/datasets/${props.dataset.id}/resources/${route.query.resource_id}/`)
+    nextTick(() => {
+      selectedResourceBanner.value?.scrollIntoView({ behavior: 'smooth' })
+    })
+  }
+  else {
+    selectedResource.value = null
+  }
+})
+
+if (import.meta.server && hasResourceId.value) {
+  useSeoMeta({
+    robots: 'noindex',
+  })
+}
+</script>

--- a/datagouv-components/src/components/ResourceExplorer/ResourceExplorer.vue
+++ b/datagouv-components/src/components/ResourceExplorer/ResourceExplorer.vue
@@ -71,7 +71,7 @@ import { useComponentsConfig } from '../../config'
 import { useTranslation } from '../../composables/useTranslation'
 import { useDebouncedRef } from '../../composables/useDebouncedRef'
 import { useFetch } from '../../functions/api'
-import { RESOURCE_TYPE } from '../../functions/resources'
+import { RESOURCE_EXPLORER_PAGE_SIZE, RESOURCE_TYPE } from '../../functions/resources'
 import type { PaginatedArray } from '../../types/api'
 import type { DatasetV2 } from '../../types/datasets'
 import type { Resource, ResourceGroup, ResourceType } from '../../types/resources'
@@ -94,7 +94,6 @@ const sidebarCollapsed = ref(false)
 const search = ref('')
 const { debounced: searchDebounced, flush } = useDebouncedRef(search, config.searchDebounce ?? 300)
 
-const PAGE_SIZE = 10
 const url = computed(() => `/api/2/datasets/${props.dataset.id}/resources/`)
 
 // Resource ID from URL query
@@ -103,32 +102,32 @@ const resourceIdQuery = useRouteQuery<string | undefined>('resource_id')
 // Fetch resources for each type
 const mainParams = computed(() => ({
   type: 'main' as const,
-  page_size: PAGE_SIZE,
+  page_size: RESOURCE_EXPLORER_PAGE_SIZE,
   q: searchDebounced.value || undefined,
 }))
 const documentationParams = computed(() => ({
   type: 'documentation' as const,
-  page_size: PAGE_SIZE,
+  page_size: RESOURCE_EXPLORER_PAGE_SIZE,
   q: searchDebounced.value || undefined,
 }))
 const updateParams = computed(() => ({
   type: 'update' as const,
-  page_size: PAGE_SIZE,
+  page_size: RESOURCE_EXPLORER_PAGE_SIZE,
   q: searchDebounced.value || undefined,
 }))
 const apiParams = computed(() => ({
   type: 'api' as const,
-  page_size: PAGE_SIZE,
+  page_size: RESOURCE_EXPLORER_PAGE_SIZE,
   q: searchDebounced.value || undefined,
 }))
 const codeParams = computed(() => ({
   type: 'code' as const,
-  page_size: PAGE_SIZE,
+  page_size: RESOURCE_EXPLORER_PAGE_SIZE,
   q: searchDebounced.value || undefined,
 }))
 const otherParams = computed(() => ({
   type: 'other' as const,
-  page_size: PAGE_SIZE,
+  page_size: RESOURCE_EXPLORER_PAGE_SIZE,
   q: searchDebounced.value || undefined,
 }))
 
@@ -169,7 +168,7 @@ const loadMoreType = ref<ResourceType>('main')
 const loadMorePage = ref(1)
 const loadMoreParams = computed(() => ({
   type: loadMoreType.value,
-  page_size: PAGE_SIZE,
+  page_size: RESOURCE_EXPLORER_PAGE_SIZE,
   page: loadMorePage.value,
   q: searchDebounced.value || undefined,
 }))

--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -91,6 +91,11 @@ export function getResourceTitleId(resource: Resource) {
 export const RESOURCE_TYPE = readonly(['main', 'documentation', 'update', 'api', 'code', 'other'] as const)
 export type ResourceType = typeof RESOURCE_TYPE[number]
 
+// Page size used by ResourceExplorer for its per-type resource fetches.
+// Exported so consumers (e.g. the dataset page's `main` prefetch) can build a
+// byte-for-byte identical cache key and let Nuxt dedupe the request.
+export const RESOURCE_EXPLORER_PAGE_SIZE = 10
+
 export const getResourceLabel = (type: ResourceType, count?: number) => {
   const { t } = useTranslation()
   switch (type) {

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -606,10 +606,15 @@ onMounted(async () => {
   ])
 })
 
-const { data: resources } = await useAPI<PaginatedArray<Resource>>(
-  `/api/2/datasets/${route.params.did}/resources/`,
-  { query: { type: 'main' } },
-)
+// Use the same cache key as ResourceExplorer's `main` fetch (dataset id + identical params)
+// so Nuxt dedupes the two into a single request on the resources tab. `q: undefined` mirrors
+// the explorer's params exactly: without it the keys differ and both requests fire.
+const { data: resources } = dataset.value
+  ? await useAPI<PaginatedArray<Resource>>(
+      `/api/2/datasets/${dataset.value.id}/resources/`,
+      { query: { type: 'main', page_size: 10, q: undefined } },
+    )
+  : { data: ref<PaginatedArray<Resource> | null>(null) }
 const exploreUrl = computed(() => {
   if (!resources.value) return null
   for (const resource of resources.value.data) {

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -490,6 +490,7 @@ import {
   type DatasetMetrics,
   TranslationT,
   getDescriptionShort,
+  RESOURCE_EXPLORER_PAGE_SIZE,
 } from '@datagouv/components-next'
 import {
   RiDeleteBinLine,
@@ -611,12 +612,12 @@ onMounted(async () => {
 // must stay byte-for-byte identical to the explorer's `mainParams`, otherwise the keys diverge
 // and both requests fire again (silent perf regression, no error, no failing test):
 //   - dataset id (not route.params.did, which can be a slug)
-//   - page_size: 10 must match ResourceExplorer's PAGE_SIZE constant (not exported, keep in sync)
+//   - page_size: shared RESOURCE_EXPLORER_PAGE_SIZE so the two stay in sync
 //   - q: undefined mirrors the explorer's `q: searchDebounced || undefined` at rest
 const { data: resources } = dataset.value
   ? await useAPI<PaginatedArray<Resource>>(
       `/api/2/datasets/${dataset.value.id}/resources/`,
-      { query: { type: 'main', page_size: 10, q: undefined } },
+      { query: { type: 'main', page_size: RESOURCE_EXPLORER_PAGE_SIZE, q: undefined } },
     )
   : { data: ref<PaginatedArray<Resource> | null>(null) }
 const exploreUrl = computed(() => {

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -607,8 +607,12 @@ onMounted(async () => {
 })
 
 // Use the same cache key as ResourceExplorer's `main` fetch (dataset id + identical params)
-// so Nuxt dedupes the two into a single request on the resources tab. `q: undefined` mirrors
-// the explorer's params exactly: without it the keys differ and both requests fire.
+// so Nuxt dedupes the two into a single request on the resources tab. Every part of the key
+// must stay byte-for-byte identical to the explorer's `mainParams`, otherwise the keys diverge
+// and both requests fire again (silent perf regression, no error, no failing test):
+//   - dataset id (not route.params.did, which can be a slug)
+//   - page_size: 10 must match ResourceExplorer's PAGE_SIZE constant (not exported, keep in sync)
+//   - q: undefined mirrors the explorer's `q: searchDebounced || undefined` at rest
 const { data: resources } = dataset.value
   ? await useAPI<PaginatedArray<Resource>>(
       `/api/2/datasets/${dataset.value.id}/resources/`,

--- a/pages/datasets/[did]/index.vue
+++ b/pages/datasets/[did]/index.vue
@@ -1,118 +1,24 @@
 <template>
   <div class="space-y-5">
-    <template v-if="useNewExplorer">
-      <ResourceExplorer
-        :dataset
-        no-results-image="/illustrations/dataset.svg"
-      />
-    </template>
-
-    <template v-else>
-      <div
-        v-if="selectedResource"
-        ref="selectedResourceBannerRef"
-        class="space-y-4"
-      >
-        <SimpleBanner
-
-          type="primary"
-          class="flex justify-between items-center"
-        >
-          <p class="!mb-0">
-            {{ $t('Vous consultez une resource spécifique.') }}
-          </p>
-          <BrandedButton
-            color="tertiary"
-            keep-margins-even-without-borders
-            :icon="RiCloseCircleLine"
-            :href="{ name: route.name, params: route.params, query: { ...route.query, resource_id: undefined } }"
-          >
-            {{ $t("Voir toutes les resources") }}
-          </BrandedButton>
-        </SimpleBanner>
-        <ResourceAccordion
-          :dataset
-          :resource="selectedResource"
-          expanded-on-mount
-          :can-edit="dataset.permissions.edit_resources"
-        />
-      </div>
-
-      <div
-        v-for="{ data, status }, index in resourcesByTypes"
-        v-else
-        :key="RESOURCE_TYPE[index]"
-        class="space-y-1"
-      >
-        <div
-          v-if="data.value"
-          class="uppercase text-gray-plain text-sm font-bold"
-        >
-          {{ getResourceLabel(RESOURCE_TYPE[index], data.value.total) }}
-        </div>
-        <div class="space-y-2.5">
-          <SearchInput
-            v-if="data.value && (data.value.total > data.value.page_size || searchByResourceType[index].value)"
-            v-model="searchByResourceType[index].value"
-            :placeholder="$t('Rechercher')"
-          />
-          <LoadingBlock
-            v-slot="{ data: resourcesData }"
-            :status="status.value"
-            :data="data.value"
-          >
-            <div class="space-y-2.5">
-              <ResourceAccordion
-                v-for="resource in resourcesData.data"
-                :key="resource.id"
-                :dataset
-                :resource
-                :can-edit="dataset.permissions.edit_resources"
-              />
-              <Pagination
-                :total-results="resourcesData.total"
-                :page-size="resourcesData.page_size"
-                :page="resourcesData.page"
-                @change="(newPage) => pageByResourceType[index].value = newPage"
-              />
-            </div>
-            <div
-              v-if="!resourcesData.total"
-              class="flex flex-col items-center"
-            >
-              <img
-                src="/illustrations/dataset.svg"
-                class="h-20"
-                alt=""
-              >
-              <p class="fr-text--bold fr-my-3v">
-                {{ $t(`Pas de résultats pour « {q} »`, { q: searchByResourceType[index].value }) }}
-              </p>
-              <BrandedButton
-                color="primary"
-                @click="searchByResourceType[index].value = ''"
-              >
-                {{ $t('Réinitialiser les filtres') }}
-              </BrandedButton>
-            </div>
-          </LoadingBlock>
-        </div>
-      </div>
-    </template>
+    <ResourceExplorer
+      v-if="useNewExplorer"
+      :dataset
+      no-results-image="/illustrations/dataset.svg"
+    />
+    <DatasetsLegacyResourceList
+      v-else
+      :dataset
+    />
 
     <RecommendationsDatasets :dataset />
   </div>
 </template>
 
 <script setup lang="ts">
-import { BrandedButton, getResourceLabel, LoadingBlock, Pagination, RESOURCE_TYPE, ResourceAccordion, ResourceExplorer, SearchInput, SimpleBanner, type DatasetV2, type Resource } from '@datagouv/components-next'
-import { RiCloseCircleLine } from '@remixicon/vue'
-import { refDebounced } from '@vueuse/core'
-import type { PaginatedArray } from '~/types/types'
+import { ResourceExplorer, type DatasetV2 } from '@datagouv/components-next'
 
-const props = defineProps<{ dataset: DatasetV2 }>()
+defineProps<{ dataset: DatasetV2 }>()
 
-const config = useRuntimeConfig()
 const route = useRoute()
 
 // Feature flag: ?new_explorer=1 to enable, ?new_explorer=0 to disable, persisted in cookie
@@ -126,66 +32,4 @@ else if (queryFlag === '0') {
 }
 // useCookie uses `destr` which deserializes '1' as the number 1
 const useNewExplorer = computed(() => String(newExplorerCookie.value) === '1')
-
-// --- Old layout logic (only used when useNewExplorer is false) ---
-const url = computed(() => `/api/2/datasets/${props.dataset.id}/resources/`)
-const pageSize = ref(10)
-
-const pageByResourceType: Array<Ref<number>> = RESOURCE_TYPE.map(() => ref(1))
-const searchByResourceType: Array<Ref<string>> = RESOURCE_TYPE.map(() => ref(''))
-const searchDebouncedByResourceType: Array<Ref<string>> = searchByResourceType.map(ref => refDebounced(ref, config.public.searchDebounce))
-
-watch(searchByResourceType, (newQueries, oldQueries) => {
-  for (const index in newQueries) {
-    if (newQueries[index] != oldQueries[index]) {
-      pageByResourceType[index].value = 1
-    }
-  }
-})
-
-const queryParamsByResourceType = RESOURCE_TYPE.map((type, index) => {
-  return computed(() => ({
-    type,
-    page_size: pageSize.value,
-    page: pageByResourceType[index].value,
-    q: searchDebouncedByResourceType[index].value,
-  }))
-})
-
-const rawResourcesByTypes = await Promise.all(
-  RESOURCE_TYPE.map((type, index) => useAPI<PaginatedArray<Resource>>(url, { query: queryParamsByResourceType[index] })),
-)
-
-const resourcesByTypes = computed(() => {
-  const result = {} as Record<number, typeof rawResourcesByTypes[number]>
-  for (let i = 0; i < rawResourcesByTypes.length; i++) {
-    if ((rawResourcesByTypes[i].data.value?.total ?? 0) > 0 || searchByResourceType[i].value) {
-      result[i] = rawResourcesByTypes[i]
-    }
-  }
-  return result
-})
-
-const hasResourceId = computed(() => 'resource_id' in route.query && route.query.resource_id)
-const { $api } = useNuxtApp()
-const selectedResource = ref<Resource | null>(null)
-const selectedResourceBanner = useTemplateRef('selectedResourceBannerRef')
-watchEffect(async () => {
-  if (useNewExplorer.value) return
-  if (hasResourceId.value) {
-    selectedResource.value = await $api<Resource>(`/api/1/datasets/${props.dataset.id}/resources/${route.query.resource_id}/`)
-    nextTick(() => {
-      selectedResourceBanner.value?.scrollIntoView({ behavior: 'smooth' })
-    })
-  }
-  else {
-    selectedResource.value = null
-  }
-})
-
-if (import.meta.server && hasResourceId.value) {
-  useSeoMeta({
-    robots: 'noindex',
-  })
-}
 </script>

--- a/pages/datasets/[did]/index.vue
+++ b/pages/datasets/[did]/index.vue
@@ -32,4 +32,14 @@ else if (queryFlag === '0') {
 }
 // useCookie uses `destr` which deserializes '1' as the number 1
 const useNewExplorer = computed(() => String(newExplorerCookie.value) === '1')
+
+// A resource selected via ?resource_id duplicates content from the main dataset page,
+// so it must stay out of the search index. Kept at the page level (not in a child
+// component) so it applies whichever explorer renders the resources.
+const hasResourceId = computed(() => 'resource_id' in route.query && route.query.resource_id)
+if (import.meta.server && hasResourceId.value) {
+  useSeoMeta({
+    robots: 'noindex',
+  })
+}
 </script>


### PR DESCRIPTION
The legacy accordion and the new duplicates the calls  to `https://demo.data.gouv.fr/api/2/datasets/5eebbc067a14b6fecc9c9976/resources/?type=documentation&page_size=10&lang=fr` for all types. This calls are slow so we don't want to do them twice (once is really enough).

Also fix the explore button to use the same URL than the accordion to allow Nuxt to de-duplicate the request too between components.