### PR TITLE
fix(search): regression on type navigation

### DIFF
--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -27,8 +27,9 @@
               {{ t('Type') }}
             </template>
             <RadioGroup
-              v-model="currentType"
+              :model-value="currentType"
               name="search-type"
+              @update:model-value="onRadioTypeChange"
             >
               <RadioInput
                 v-for="typeConfig in config"
@@ -549,13 +550,25 @@ const allFilters: Record<string, Ref<unknown>> = {
   type: reuseType,
 }
 
+let typeChangedInternally = false
+
+function onRadioTypeChange(newType: string) {
+  typeChangedInternally = true
+  currentType.value = newType
+}
+
 // Reset page, sort and filters when changing type. Every reset below goes
 // through useRouteQuery, so VueUse coalesces them into a single router.replace
-// (its shared _queriesQueue flushes once on nextTick). Custom filters are NOT
-// cleared here: type-scoped ones are cleared in useSearchFilter's onScopeDispose
-// (fires after navigation in parent-driven type switches, so route.query is already
-// up-to-date and no replace is issued — no race with the parent's router.push).
+// (its shared _queriesQueue flushes once on nextTick). Custom filters are cleared
+// here too, rather than in useSearchFilter's onunmount, so their URL change joins
+// that same batch instead of racing it with a separate router.replace.
+// Only runs when typeChangedInternally is set (radio click); parent-driven type
+// switches skip this to avoid racing a concurrent parent router.push().
 watch(currentType, () => {
+  const wasInternal = typeChangedInternally
+  typeChangedInternally = false
+  if (!wasInternal) return
+
   // page=1 is the default and is dropped from the URL, so only reset when needed.
   if (page.value !== 1) page.value = 1
 
@@ -569,6 +582,13 @@ watch(currentType, () => {
   for (const [filterName, filterRef] of Object.entries(allFilters)) {
     if (filterRef.value !== undefined && !activeFilters.value.includes(filterName)) {
       filterRef.value = undefined
+    }
+  }
+
+  // Reset type-scoped custom filters that don't apply to the new type
+  for (const entry of customFilterRegistry.values()) {
+    if (entry.typeKeys && !entry.typeKeys.includes(currentType.value) && isCustomFilterActive(entry)) {
+      entry.ref.value = entry.defaultValue
     }
   }
 })

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -551,9 +551,10 @@ const allFilters: Record<string, Ref<unknown>> = {
 
 // Reset page, sort and filters when changing type. Every reset below goes
 // through useRouteQuery, so VueUse coalesces them into a single router.replace
-// (its shared _queriesQueue flushes once on nextTick). Custom filters are cleared
-// here too, rather than in useSearchFilter's onunmount, so their URL change joins
-// that same batch instead of racing it with a separate router.replace.
+// (its shared _queriesQueue flushes once on nextTick). Custom filters are NOT
+// cleared here: type-scoped ones are cleared in useSearchFilter's onScopeDispose
+// (fires after navigation in parent-driven type switches, so route.query is already
+// up-to-date and no replace is issued — no race with the parent's router.push).
 watch(currentType, () => {
   // page=1 is the default and is dropped from the URL, so only reset when needed.
   if (page.value !== 1) page.value = 1
@@ -568,13 +569,6 @@ watch(currentType, () => {
   for (const [filterName, filterRef] of Object.entries(allFilters)) {
     if (filterRef.value !== undefined && !activeFilters.value.includes(filterName)) {
       filterRef.value = undefined
-    }
-  }
-
-  // Reset type-scoped custom filters that don't apply to the new type
-  for (const entry of customFilterRegistry.values()) {
-    if (entry.typeKeys && !entry.typeKeys.includes(currentType.value) && isCustomFilterActive(entry)) {
-      entry.ref.value = entry.defaultValue
     }
   }
 })

--- a/datagouv-components/src/composables/useSearchFilter.ts
+++ b/datagouv-components/src/composables/useSearchFilter.ts
@@ -94,21 +94,20 @@ export function useSearchFilter(
   })
 
   onScopeDispose(() => {
+    // Type-scoped filters (typeKeys set) are cleared by GlobalSearch's
+    // watch(currentType) instead, so their URL update batches with the other
+    // type-change resets via useRouteQuery rather than racing them with the
+    // separate router.replace below. Here we only clear filters that apply to
+    // all types: their unmount is a consumer signal unrelated to a type switch,
+    // which GlobalSearch has no way to detect.
+    //
     // We cannot use `value.value = defaultValue` here because VueUse's
     // useRouteQuery registers its own tryOnScopeDispose cleanup that zeroes
     // the internal `query` variable to undefined (FIFO order, it runs first).
     // The setter then sees `query === v` and early-returns without ever
     // calling router.replace(). Instead we read the live route.query directly
     // (which is router state, not affected by that cleanup) and push the update.
-    //
-    // For type-scoped filters (typeKeys set): in a parent-driven type switch
-    // (router.push to a new route), the filter component unmounts AFTER navigation
-    // commits, at which point route.query no longer contains the param → the
-    // condition below is false and no router.replace() is issued — no race with
-    // the parent's push. In an in-page type switch (same route), the component
-    // unmounts synchronously, route.query still has the old value, and the
-    // replace clears it correctly.
-    if (route.query[urlParam] !== undefined) {
+    if (normalizedTypeKeys === undefined && route.query[urlParam] !== undefined) {
       const { [urlParam]: _removed, ...restQuery } = route.query
       router.replace({
         query: defaultValue === undefined ? restQuery : { ...restQuery, [urlParam]: String(defaultValue) },

--- a/datagouv-components/src/composables/useSearchFilter.ts
+++ b/datagouv-components/src/composables/useSearchFilter.ts
@@ -94,20 +94,21 @@ export function useSearchFilter(
   })
 
   onScopeDispose(() => {
-    // Type-scoped filters (typeKeys set) are cleared by GlobalSearch's
-    // watch(currentType) instead, so their URL update batches with the other
-    // type-change resets via useRouteQuery rather than racing them with the
-    // separate router.replace below. Here we only clear filters that apply to
-    // all types: their unmount is a consumer signal unrelated to a type switch,
-    // which GlobalSearch has no way to detect.
-    //
     // We cannot use `value.value = defaultValue` here because VueUse's
     // useRouteQuery registers its own tryOnScopeDispose cleanup that zeroes
     // the internal `query` variable to undefined (FIFO order, it runs first).
     // The setter then sees `query === v` and early-returns without ever
     // calling router.replace(). Instead we read the live route.query directly
     // (which is router state, not affected by that cleanup) and push the update.
-    if (normalizedTypeKeys === undefined && route.query[urlParam] !== undefined) {
+    //
+    // For type-scoped filters (typeKeys set): in a parent-driven type switch
+    // (router.push to a new route), the filter component unmounts AFTER navigation
+    // commits, at which point route.query no longer contains the param → the
+    // condition below is false and no router.replace() is issued — no race with
+    // the parent's push. In an in-page type switch (same route), the component
+    // unmounts synchronously, route.query still has the old value, and the
+    // replace clears it correctly.
+    if (route.query[urlParam] !== undefined) {
       const { [urlParam]: _removed, ...restQuery } = route.query
       router.replace({
         query: defaultValue === undefined ? restQuery : { ...restQuery, [urlParam]: String(defaultValue) },


### PR DESCRIPTION
#1148 broke the navigation between types with type-scoped filters, cf https://github.com/opendatateam/udata-front-kit/actions/runs/27694406152/job/81913620279 failing tests. This is an attempt to fix the behaviour but handling those filters differently.