### PR TITLE
fix: not showing tabular preview in case of map error

### DIFF
--- a/datagouv-components/src/components/ResourceExplorer/ResourceExplorerViewer.vue
+++ b/datagouv-components/src/components/ResourceExplorer/ResourceExplorerViewer.vue
@@ -122,6 +122,11 @@
                 v-if="ogcWms"
                 :resource="resource"
               />
+              <PreviewUnavailable v-if="!hasPmtiles && !ogcWms && hasPmtilesError">
+                {{ t("La carte n'a pas pu être générée automatiquement pour ce fichier.") }}
+                <br>
+                <span class="text-gray-medium text-xs">{{ pmtilesError }}</span>
+              </PreviewUnavailable>
             </div>
             <div v-if="tab.key === 'data'">
               <JsonPreview
@@ -275,6 +280,8 @@ const { formatRelativeIfRecentDate } = useFormatDate()
 const {
   hasTabularData,
   hasPmtiles,
+  hasPmtilesError,
+  pmtilesError,
   hasDatafairPreview,
   hasOpenAPIPreview,
   ogcService,

--- a/datagouv-components/src/composables/useHasTabularData.ts
+++ b/datagouv-components/src/composables/useHasTabularData.ts
@@ -1,4 +1,5 @@
 import { useComponentsConfig } from '../config'
+import { hasTabularParsingError } from '../functions/resources'
 import type { Resource } from '../types/resources'
 
 /**
@@ -20,7 +21,7 @@ export const useHasTabularData = () => {
     return (
       config.tabularApiUrl
       && resource.extras['analysis:parsing:parsing_table']
-      && !resource.extras['analysis:parsing:error']
+      && !hasTabularParsingError(resource)
       && !sourceUnreachable
       && (config.tabularAllowRemote || resource.filetype === 'file')
     )

--- a/datagouv-components/src/composables/useResourceCapabilities.ts
+++ b/datagouv-components/src/composables/useResourceCapabilities.ts
@@ -2,7 +2,7 @@ import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import { useComponentsConfig } from '../config'
 import { useTranslation } from './useTranslation'
 import { useHasTabularData } from './useHasTabularData'
-import { detectOgcService } from '../functions/resources'
+import { detectOgcService, getParsingErrorMessage, getParsingErrorStep } from '../functions/resources'
 import { isOrganizationCertified } from '../functions/organizations'
 import type { Resource, WfsMetadata } from '../types/resources'
 import type { Dataset, DatasetV2 } from '../types/datasets'
@@ -49,6 +49,11 @@ export function useResourceCapabilities(
   const ogcService = computed(() => detectOgcService(toValue(resource)))
   const ogcWms = computed(() => ogcService.value === 'wms')
 
+  // The map is built from a pmtiles export; when that export fails we still want
+  // to show the Carte tab, but with the reason it could not be generated.
+  const hasPmtilesError = computed(() => getParsingErrorStep(toValue(resource)) === 'pmtiles_export')
+  const pmtilesError = computed(() => hasPmtilesError.value ? getParsingErrorMessage(toValue(resource)) : null)
+
   const generatedFormats = computed(() => {
     const r = toValue(resource)
     const formats = GENERATED_FORMATS
@@ -85,19 +90,25 @@ export function useResourceCapabilities(
     const r = toValue(resource)
     const options = []
 
-    if (hasTabularData.value) {
-      options.push({ key: 'data', label: t('Données') })
+    const dataTab = { key: 'data', label: hasTabularData.value ? t('Données') : t('Aperçu') }
+    const mapTab = { key: 'map', label: t('Carte') }
+    const hasMap = hasPmtiles.value || ogcWms.value
+
+    // The map is the most visual preview: when it is available, show it first.
+    // When its generation failed, keep the data preview first and surface the
+    // Carte tab (with its error) right after.
+    if (hasMap) {
+      options.push(mapTab, dataTab)
+    }
+    else if (hasPmtilesError.value) {
+      options.push(dataTab, mapTab)
     }
     else {
-      options.push({ key: 'data', label: t('Aperçu') })
+      options.push(dataTab)
     }
 
     if (hasTabularData.value) {
       options.push({ key: 'data-structure', label: t('Structure des données') })
-    }
-
-    if (hasPmtiles.value || ogcWms.value) {
-      options.push({ key: 'map', label: t('Carte') })
     }
 
     if (r.description) {
@@ -118,6 +129,8 @@ export function useResourceCapabilities(
     hasPreview,
     hasTabularData,
     hasPmtiles,
+    hasPmtilesError,
+    pmtilesError,
     hasDatafairPreview,
     hasOpenAPIPreview,
     ogcService,

--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -175,7 +175,7 @@ export function getParsingErrorStep(resource: Resource): string | null {
   const error = resource.extras['analysis:parsing:error']
   if (typeof error !== 'string' || !error) return null
   const [step] = error.split(':', 1)
-  return step
+  return step ?? null
 }
 
 /** The parsing error message without its `<step>:` prefix, or null when there is none. */

--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -167,6 +167,40 @@ export function getResourceFilesize(resource: Resource): null | number {
   return null
 }
 
+// Parsing errors are stored as `<step>:<message>`, where `<step>` names the
+// analysis step that failed (e.g. `pmtiles_export`, `geojson_export`).
+
+/** The analysis step that failed, or null when there is no parsing error. */
+export function getParsingErrorStep(resource: Resource): string | null {
+  const error = resource.extras['analysis:parsing:error']
+  if (typeof error !== 'string' || !error) return null
+  const [step] = error.split(':', 1)
+  return step
+}
+
+/** The parsing error message without its `<step>:` prefix, or null when there is none. */
+export function getParsingErrorMessage(resource: Resource): string | null {
+  const error = resource.extras['analysis:parsing:error']
+  if (typeof error !== 'string' || !error) return null
+  const colon = error.indexOf(':')
+  return colon === -1 ? error : error.slice(colon + 1)
+}
+
+// Geo/format export steps run *after* the tabular table has been built, so a
+// failure here (e.g. a huge geometry timing out the pmtiles export) leaves the
+// tabular data fully usable and must not disable the tabular explorer.
+const NON_TABULAR_PARSING_ERROR_STEPS = ['pmtiles_export', 'geojson_export']
+
+/**
+ * Whether the resource's parsing error prevents reading its tabular data.
+ * Only errors from the tabular parsing itself are fatal; downstream geo/format
+ * export failures are not.
+ */
+export function hasTabularParsingError(resource: Resource): boolean {
+  const step = getParsingErrorStep(resource)
+  return step !== null && !NON_TABULAR_PARSING_ERROR_STEPS.includes(step)
+}
+
 type CorsStatus = 'allowed' | 'blocked' | 'unknown'
 
 export const getResourceCorsStatus = (resource: Resource): CorsStatus => {

--- a/tests-unit/datagouv-components/tabular-parsing-error.spec.ts
+++ b/tests-unit/datagouv-components/tabular-parsing-error.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest'
+import { getParsingErrorMessage, getParsingErrorStep, hasTabularParsingError } from '~/datagouv-components/src/functions/resources'
+import type { Resource } from '~/datagouv-components/src/types/resources'
+
+const resourceWithError = (error?: unknown): Resource =>
+  ({ extras: error === undefined ? {} : { 'analysis:parsing:error': error } } as unknown as Resource)
+
+test('no parsing error is not fatal for tabular data', () => {
+  expect(hasTabularParsingError(resourceWithError())).toBe(false)
+})
+
+// A huge geometry makes the pmtiles export time out while the tabular table is
+// still built: the tabular data must stay available (data.gouv.fr catalogue bug).
+test('pmtiles_export timeout does not block tabular data', () => {
+  expect(hasTabularParsingError(
+    resourceWithError('pmtiles_export:Task exceeded maximum timeout value (3600 seconds)'),
+  )).toBe(false)
+})
+
+test('geojson_export error does not block tabular data', () => {
+  expect(hasTabularParsingError(
+    resourceWithError('geojson_export:Task exceeded maximum timeout value (3600 seconds)'),
+  )).toBe(false)
+})
+
+test('a tabular parsing error is fatal', () => {
+  expect(hasTabularParsingError(
+    resourceWithError('parse_error:could not detect a valid CSV'),
+  )).toBe(true)
+})
+
+test('an unprefixed error is treated as fatal', () => {
+  expect(hasTabularParsingError(resourceWithError('something went wrong'))).toBe(true)
+})
+
+test('getParsingErrorStep extracts the failed step', () => {
+  expect(getParsingErrorStep(resourceWithError('pmtiles_export:Task exceeded maximum timeout value (3600 seconds)'))).toBe('pmtiles_export')
+  expect(getParsingErrorStep(resourceWithError('unprefixed message'))).toBe('unprefixed message')
+  expect(getParsingErrorStep(resourceWithError())).toBe(null)
+})
+
+// The message keeps everything after the step prefix, including colons in the
+// message itself (e.g. a timestamp).
+test('getParsingErrorMessage strips only the step prefix', () => {
+  expect(getParsingErrorMessage(resourceWithError('pmtiles_export:Task exceeded maximum timeout value (3600 seconds)'))).toBe('Task exceeded maximum timeout value (3600 seconds)')
+  expect(getParsingErrorMessage(resourceWithError('unprefixed message'))).toBe('unprefixed message')
+  expect(getParsingErrorMessage(resourceWithError())).toBe(null)
+})


### PR DESCRIPTION
- [x] show tabular preview even if there is a map error
- [x] show map tab before tabular preview if there is any (in `new_explorer=1`)
- [x] show map tab (after preview) if there is pmtiles errors to better explain to users why there is no map (in `new_explorer=1`)