### PR TITLE
feat: use openweight-large as the AI model

### DIFF
--- a/server/routes/nuxt-api/albert/generate-dataset-short-description.post.ts
+++ b/server/routes/nuxt-api/albert/generate-dataset-short-description.post.ts
@@ -57,11 +57,9 @@ export default defineEventHandler(async (event) => {
     },
   ]
 
-  // Models available for text generation:
-  // - openweight-small (replaces albert-small)
-  // - openweight-medium (replaces albert-large)
-  // - openweight-large
-  const generatedDescriptionShort = await callAlbertAPI(messages, 'openweight-small')
+  // To list available models:
+  // curl -sS -H "Authorization: Bearer $ALBERT_API_KEY" -H "Content-Type: application/json" "https://albert.api.etalab.gouv.fr/v1/models"
+  const generatedDescriptionShort = await callAlbertAPI(messages, 'openweight-large')
 
   // Ensure the description doesn't exceed maxChars
   const finalDescriptionShort = generatedDescriptionShort.length > DESCRIPTION_SHORT_MAX_LENGTH

--- a/server/routes/nuxt-api/albert/generate-dataset-tags.post.ts
+++ b/server/routes/nuxt-api/albert/generate-dataset-tags.post.ts
@@ -66,11 +66,9 @@ export default defineEventHandler(async (event) => {
     },
   ]
 
-  // Models available for text generation:
-  // - openweight-small (replaces albert-small)
-  // - openweight-medium (replaces albert-large)
-  // - openweight-large
-  const generatedTags = await callAlbertAPI(messages, 'openweight-small')
+  // To list available models:
+  // curl -sS -H "Authorization: Bearer $ALBERT_API_KEY" -H "Content-Type: application/json" "https://albert.api.etalab.gouv.fr/v1/models"
+  const generatedTags = await callAlbertAPI(messages, 'openweight-large')
 
   // Parse the comma-separated tags and clean them
   const tags = parseTags(generatedTags, nbTags)

--- a/server/routes/nuxt-api/albert/generate-reuse-tags.post.ts
+++ b/server/routes/nuxt-api/albert/generate-reuse-tags.post.ts
@@ -66,11 +66,9 @@ export default defineEventHandler(async (event) => {
     },
   ]
 
-  // Models available for text generation:
-  // - openweight-small (replaces albert-small)
-  // - openweight-medium (replaces albert-large)
-  // - openweight-large
-  const generatedTags = await callAlbertAPI(messages, 'openweight-small')
+  // To list available models:
+  // curl -sS -H "Authorization: Bearer $ALBERT_API_KEY" -H "Content-Type: application/json" "https://albert.api.etalab.gouv.fr/v1/models"
+  const generatedTags = await callAlbertAPI(messages, 'openweight-large')
 
   // Parse the comma-separated tags and clean them
   const tags = parseTags(generatedTags, nbTags)


### PR DESCRIPTION
Albert text-generation features were calling `openweight-small`, which points to an **image-text-to-text** model, which is a multimodal model type. It work for text-only prompts, but it is a strong signal it is not the right default for tag/description generation.

This change switches all three endpoints to `openweight-large` (`openai/gpt-oss-120b`) which is a type `text-to-text` (pure text generation model) and replaces the outdated model comments with a curl command to inspect the live model list.

Querying `https://albert.api.etalab.gouv.fr/v1/models` shows:
```shell
openai/gpt-oss-120b (aliases: openweight-large)
Type: text-generation
Created: 1765375160
Owned by: Services du premier ministre - DINUM
Max context length: 131072

Qwen/Qwen3-Coder-30B-A3B-Instruct (aliases: openweight-code)
Type: text-generation
Created: 1765384283
Owned by: Services du premier ministre - DINUM
Max context length: 262144

mistralai/Ministral-3-8B-Instruct-2512 (aliases: openweight-small)
Type: image-text-to-text
Created: 1765384336
Owned by: Services du premier ministre - DINUM
Max context length: 262144

BAAI/bge-m3 (aliases: openweight-embeddings)
Type: text-embeddings-inference
Created: 1765384417
Owned by: Services du premier ministre - DINUM
Max context length: 8192

BAAI/bge-reranker-v2-m3 (aliases: openweight-rerank)
Type: text-classification
Created: 1765384523
Owned by: Services du premier ministre - DINUM
Max context length: 8192

mistralai/Mistral-Small-3.2-24B-Instruct-2506 (aliases: openweight-medium, albert-large)
Type: image-text-to-text
Created: 1765979887
Owned by: Services du premier ministre - DINUM
Max context length: 128000

openai/whisper-large-v3 (aliases: openweight-audio)
Type: automatic-speech-recognition
Created: 1778071574
Owned by: Services du premier ministre - DINUM
```
