### PR TITLE
fix: bind devServer to ::

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -240,7 +240,12 @@ export default defineNuxtConfig({
 
   devServer: {
     port: 3000,
-    host: 'dev.local',
+    // Bind to the IPv6/IPv4 "any" wildcard rather than resolving the 'dev.local'
+    // hostname at listen-time: Node's dns.lookup() for a hostname follows live
+    // OS network-state ordering (RFC 6724) since Node 17, so binding to only
+    // whichever family the OS prefers *right now* silently flips between IPv4
+    // and IPv6 across sleep/wake or network changes, breaking dev.local access.
+    host: '::',
   },
 
   features: {


### PR DESCRIPTION
`dev.local:3000` suddenly failed to resolve on my local mac. This is apparently due to an ipv4/ipv6 switch from the os resolver. This PR binds the dev server to any local stack instead of forcing the resolution of a given hostname.

Should work on Linux too, but didn't test.