### PR TITLE
fix(tests): wait for chart image upload before reloading in e2e tests

### DIFF
--- a/tests/visualizations/chart-configurator.spec.ts
+++ b/tests/visualizations/chart-configurator.spec.ts
@@ -604,6 +604,9 @@ test('y-axis columns should not be empty after selecting resource from loaded ch
   const saveResponsePromise = page.waitForResponse(response =>
     response.url().includes('/api/1/visualizations/') && response.request().method() === 'POST',
   )
+  const imageResponsePromise = page.waitForResponse(response =>
+    response.url().includes('/image/') && response.request().method() === 'POST',
+  )
   const getPromise = page.waitForResponse(response =>
     response.url().includes('/api/1/visualizations/') && response.request().method() === 'GET',
   )
@@ -611,6 +614,7 @@ test('y-axis columns should not be empty after selecting resource from loaded ch
   const saveResponse = await saveResponsePromise
   const chartData = (await saveResponse.json()) as Chart
   await getPromise
+  await imageResponsePromise
 
   await page.reload()
   await page.waitForLoadState('networkidle')
@@ -645,11 +649,15 @@ test('x-axis dropdown should show columns from all chart resources after loading
   const saveResponsePromise = page.waitForResponse(response =>
     response.url().includes('/api/1/visualizations/') && response.request().method() === 'POST',
   )
+  const imageResponsePromise = page.waitForResponse(response =>
+    response.url().includes('/image/') && response.request().method() === 'POST',
+  )
   await page.getByLabel('Titre').fill('Test All Columns Loaded')
   await page.getByLabel('Description').fill('Test')
   await page.getByRole('button', { name: 'Sauvegarder le graphique' }).click()
   const saveResponse = await saveResponsePromise
   const chartData = (await saveResponse.json()) as Chart
+  await imageResponsePromise
 
   await page.reload()
   await page.waitForLoadState('networkidle')


### PR DESCRIPTION
## Summary
- `e2e (chromium, 2)` has been intermittently failing on `main` since 2026-07-23 on `tests/visualizations/chart-configurator.spec.ts` › *"x-axis dropdown should show columns from all chart resources after loading"*, with `Failed to save chart: FetchError ... POST .../image/ <no response>`.
- Root cause: #1111 made `saveChart()` upload a chart preview image (`POST /api/1/visualizations/{id}/image/`) after the visualization-creation POST resolves, but two tests only awaited that first POST before calling `page.reload()`. Under CI load the image upload is sometimes still in flight, so the reload aborts it and the resulting console error trips the `assertNoConsoleErrors` fixture.
- Fix: also wait for the `/image/` upload POST to resolve before reloading, in both affected tests.

## Test plan
- [x] `pnpm exec eslint tests/visualizations/chart-configurator.spec.ts` passes
- [x] `pnpm run typecheck` passes
- [ ] CI `e2e (chromium, 2)` passes (this is what we're fixing — watch this run)