### PR TITLE
fix: stop auth links and 401 redirects from nesting next into itself

### DIFF
--- a/components/SiteHeader/SiteHeader.vue
+++ b/components/SiteHeader/SiteHeader.vue
@@ -122,7 +122,7 @@
                         >
                           <li>
                             <BrandedButton
-                              :href="{ path: '/login', query: { next: route.fullPath } }"
+                              :href="{ path: '/login', query: { next: nextAfterAuth } }"
                               color="tertiary"
                               size="lg"
                               :icon="RiLockLine"
@@ -136,7 +136,7 @@
                             <BrandedButton
                               color="tertiary"
                               size="lg"
-                              :href="{ path: '/register', query: { next: route.fullPath } }"
+                              :href="{ path: '/register', query: { next: nextAfterAuth } }"
                               class="w-full"
                               :icon="RiAccountCircleLine"
                               @click="close"
@@ -380,7 +380,7 @@
                 <li>
                   <BrandedButton
                     color="tertiary"
-                    :href="{ path: '/login', query: { next: route.fullPath } }"
+                    :href="{ path: '/login', query: { next: nextAfterAuth } }"
                     :icon="RiLockLine"
                   >
                     {{ $t("Se connecter") }}
@@ -389,7 +389,7 @@
                 <li>
                   <BrandedButton
                     color="tertiary"
-                    :href="{ path: '/register', query: { next: route.fullPath } }"
+                    :href="{ path: '/register', query: { next: nextAfterAuth } }"
                     :icon="RiAccountCircleLine"
                   >
                     {{ $t("S'enregistrer") }}
@@ -542,12 +542,22 @@ const { t } = useTranslation()
 const config = useRuntimeConfig()
 const appConfig = useAppConfig()
 const me = useMaybeMe()
-const currentRoute = useRoute()
 const router = useRouter()
 const route = useRoute()
 const { isLoading } = useLoadingIndicator()
 const { refreshNotifications, loadMoreNotifications, pendingNotifications, nextPage, notificationsCombinedList, notificationsToRead } = useNotifications()
 const { markWithoutActionAsRead, loading } = useMarkAsRead()
+
+// On an auth page, `next` must keep pointing at the original destination instead of the
+// current page: a self-referencing `next` makes the login and register links generate a
+// new URL on every hop (/login?next=/register?next=/login?next=…), an infinite URL space
+// that crawlers walk endlessly, each hop being a full SSR render.
+const nextAfterAuth = computed(() => {
+  if (!isUnloggedSecurityRoute(route.path)) return route.fullPath
+
+  const next = Array.isArray(route.query.next) ? route.query.next[0] : route.query.next
+  return next || undefined
+})
 
 const menu = [
   { label: t('Données'), link: '/datasets' },
@@ -577,10 +587,10 @@ const publishMenu = [
 const filteredPublishMenu = computed(() => publishMenu.filter(item => !('show' in item) || item.show))
 
 function getAriaCurrent(link: string) {
-  if (currentRoute.path === link) {
+  if (route.path === link) {
     return 'page'
   }
-  const routesInPath = router.getRoutes().map(route => route.path).filter(path => currentRoute.path.startsWith(path))
+  const routesInPath = router.getRoutes().map(({ path }) => path).filter(path => route.path.startsWith(path))
   return routesInPath.includes(link)
 }
 

--- a/middleware/redirect.global.ts
+++ b/middleware/redirect.global.ts
@@ -1,7 +1,3 @@
-const UNLOGGED_SECURITY_ROUTES = [
-  'login', 'register', 'reset', 'tf-validate',
-]
-
 export default defineNuxtRouteMiddleware((to, _from) => {
   // Strip locale prefix and redirect to version without it
   if (to.path.startsWith('/fr/') || to.path.startsWith('/en/') || to.path.startsWith('/es/')) {
@@ -20,7 +16,7 @@ export default defineNuxtRouteMiddleware((to, _from) => {
   const me = useMaybeMe()
 
   // logged user shouldn't access to login, register, etc. routes
-  if (me.value && UNLOGGED_SECURITY_ROUTES.some(route => to.path.startsWith(`/${route}`))) {
+  if (me.value && isUnloggedSecurityRoute(to.path)) {
     return navigateTo('/')
   }
 })

--- a/plugins/api.ts
+++ b/plugins/api.ts
@@ -48,11 +48,15 @@ export default defineNuxtPlugin({
           }
 
           if (response.status === 401) {
-            if (response._data?.response && typeof response._data.response === 'object' && response._data.response?.reauth_required === true) {
-              await nuxtApp.runWithContext(() => navigateTo({ path: '/verify', query: { next: route.fullPath } }))
-            }
-            else {
-              await nuxtApp.runWithContext(() => navigateTo({ path: '/login', query: { next: route.fullPath } }))
+            const reauthRequired = response._data?.response && typeof response._data.response === 'object' && response._data.response?.reauth_required === true
+            const path = reauthRequired ? '/verify' : '/login'
+
+            // Coming from the very page we would send the user to, the 401 is the expected
+            // answer to wrong credentials rather than a sign they must authenticate.
+            // Redirecting would nest `next` into itself on every attempt
+            // (/login?next=/login?next=…) and lose the actual destination.
+            if (route.path !== path) {
+              await nuxtApp.runWithContext(() => navigateTo({ path, query: { next: route.fullPath } }))
             }
           }
 

--- a/tests/auth/header-links.logged-out.spec.ts
+++ b/tests/auth/header-links.logged-out.spec.ts
@@ -6,6 +6,10 @@ const authUrl = (pathname: string, next: string | null) => (url: URL) =>
   url.pathname === pathname && url.searchParams.get('next') === next
 
 test.describe('Header auth links', () => {
+  // Reaching /register mounts a CaptchEtat image, and the captcha service is unreachable
+  // from the test environment: `/api/2/captchetat` answers 500.
+  test.use({ allowedConsoleMessages: ['the server responded with a status of 500'] })
+
   test('keep pointing at the original page instead of nesting each other', async ({ page }) => {
     await page.goto('/datasets/search')
     await page.waitForLoadState('networkidle')

--- a/tests/auth/header-links.logged-out.spec.ts
+++ b/tests/auth/header-links.logged-out.spec.ts
@@ -1,18 +1,23 @@
 import { test, expect } from '../base'
 
+// The router leaves slashes unencoded in query values, so assert on the parsed URL rather
+// than on the raw query string: what matters is where `next` points, not how it is written.
+const authUrl = (pathname: string, next: string | null) => (url: URL) =>
+  url.pathname === pathname && url.searchParams.get('next') === next
+
 test.describe('Header auth links', () => {
   test('keep pointing at the original page instead of nesting each other', async ({ page }) => {
     await page.goto('/datasets/search')
     await page.waitForLoadState('networkidle')
 
     await page.getByRole('link', { name: 'Se connecter' }).first().click()
-    await expect(page).toHaveURL(/\/login\?next=%2Fdatasets%2Fsearch$/)
+    await expect(page).toHaveURL(authUrl('/login', '/datasets/search'))
 
     await page.getByRole('link', { name: 'S\'enregistrer' }).first().click()
-    await expect(page).toHaveURL(/\/register\?next=%2Fdatasets%2Fsearch$/)
+    await expect(page).toHaveURL(authUrl('/register', '/datasets/search'))
 
     await page.getByRole('link', { name: 'Se connecter' }).first().click()
-    await expect(page).toHaveURL(/\/login\?next=%2Fdatasets%2Fsearch$/)
+    await expect(page).toHaveURL(authUrl('/login', '/datasets/search'))
   })
 
   test('carry no next param when the auth page was opened directly', async ({ page }) => {
@@ -20,6 +25,6 @@ test.describe('Header auth links', () => {
     await page.waitForLoadState('networkidle')
 
     await page.getByRole('link', { name: 'S\'enregistrer' }).first().click()
-    await expect(page).toHaveURL(/\/register$/)
+    await expect(page).toHaveURL(authUrl('/register', null))
   })
 })

--- a/tests/auth/header-links.logged-out.spec.ts
+++ b/tests/auth/header-links.logged-out.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '../base'
+
+test.describe('Header auth links', () => {
+  test('keep pointing at the original page instead of nesting each other', async ({ page }) => {
+    await page.goto('/datasets/search')
+    await page.waitForLoadState('networkidle')
+
+    await page.getByRole('link', { name: 'Se connecter' }).first().click()
+    await expect(page).toHaveURL(/\/login\?next=%2Fdatasets%2Fsearch$/)
+
+    await page.getByRole('link', { name: 'S\'enregistrer' }).first().click()
+    await expect(page).toHaveURL(/\/register\?next=%2Fdatasets%2Fsearch$/)
+
+    await page.getByRole('link', { name: 'Se connecter' }).first().click()
+    await expect(page).toHaveURL(/\/login\?next=%2Fdatasets%2Fsearch$/)
+  })
+
+  test('carry no next param when the auth page was opened directly', async ({ page }) => {
+    await page.goto('/login')
+    await page.waitForLoadState('networkidle')
+
+    await page.getByRole('link', { name: 'S\'enregistrer' }).first().click()
+    await expect(page).toHaveURL(/\/register$/)
+  })
+})

--- a/tests/auth/login.logged-out.spec.ts
+++ b/tests/auth/login.logged-out.spec.ts
@@ -38,6 +38,25 @@ test.describe('Login page', () => {
     await expect(page).toHaveURL(/\/login/)
   })
 
+  test('keeps the next param intact across failed attempts', async ({ page, baseURL }) => {
+    await page.goto('/login?next=%2Fdatasets%2Fsearch')
+    await page.waitForLoadState('networkidle')
+
+    for (const wrongPassword of ['wrong-password', 'wrong-password-again']) {
+      await page.getByLabel('Mot de passe').fill(wrongPassword)
+      await page.getByLabel('Adresse email').fill('normal@example.com')
+      await page.getByRole('button', { name: 'Se connecter' }).first().click()
+
+      await expect(page.locator('.fr-error-text').first()).toBeVisible()
+      await expect(page).toHaveURL(`${baseURL}/login?next=%2Fdatasets%2Fsearch`)
+    }
+
+    await page.getByLabel('Mot de passe').fill('@1337Password42')
+    await page.getByRole('button', { name: 'Se connecter' }).first().click()
+
+    await expect(page).toHaveURL(`${baseURL}/datasets/search`)
+  })
+
   test('shows an error with an unknown account', async ({ page }) => {
     await page.goto('/login')
     await page.waitForLoadState('networkidle')

--- a/tests/auth/login.logged-out.spec.ts
+++ b/tests/auth/login.logged-out.spec.ts
@@ -48,7 +48,7 @@ test.describe('Login page', () => {
       await page.getByRole('button', { name: 'Se connecter' }).first().click()
 
       await expect(page.locator('.fr-error-text').first()).toBeVisible()
-      await expect(page).toHaveURL(`${baseURL}/login?next=%2Fdatasets%2Fsearch`)
+      await expect(page).toHaveURL(url => url.pathname === '/login' && url.searchParams.get('next') === '/datasets/search')
     }
 
     await page.getByLabel('Mot de passe').fill('@1337Password42')

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -1,6 +1,14 @@
 import type { Organization, OrganizationReference, User } from '@datagouv/components-next'
 import { usePostApiWithCsrf } from './api'
 
+const UNLOGGED_SECURITY_ROUTES = [
+  'login', 'register', 'reset', 'tf-validate',
+]
+
+export function isUnloggedSecurityRoute(path: string): boolean {
+  return UNLOGGED_SECURITY_ROUTES.some(route => path.startsWith(`/${route}`))
+}
+
 export type Me = User & {
   about: string | null
   active: boolean


### PR DESCRIPTION
I was investigating why we have more /register and /login than homepage visits:

<img width="1111" height="216" alt="image" src="https://github.com/user-attachments/assets/7f6cc682-1006-48b4-805a-16483a5b756e" />
